### PR TITLE
Couple of tweaks / addtions 

### DIFF
--- a/intro/how-to-get-help.md
+++ b/intro/how-to-get-help.md
@@ -2,4 +2,4 @@
 
 You can get help by [joining our Discord](https://discord.gg/sTf9uYF), and asking your question in any of the `#acars` channels. There are a bunch of friendly and knowledgeable people there who would be happy to help.
 
-Furthermore, we welcome any feedback on this document. If you think a section needs better instructions or further explanation, or if anything doesn't work for you, please let us know in the Discord's `#adsb-bitbook` channel so that we can continue to improve this document. You can also [open an issue on GitHub](https://github.com/sdr-enthusiasts/acars-guide/issues) or [submit a pull request](https://github.com/sdr-enthusiasts/acars-guide/pulls) with suggested changes!
+Furthermore, we welcome any feedback on this document. If you think a section needs better instructions or further explanation, or if anything doesn't work for you, please let us know in the Discord's `#acars-guide` channel so that we can continue to improve this document. You can also [open an issue on GitHub](https://github.com/sdr-enthusiasts/acars-guide/issues) or [submit a pull request](https://github.com/sdr-enthusiasts/acars-guide/pulls) with suggested changes!

--- a/intro/overview.md
+++ b/intro/overview.md
@@ -6,5 +6,5 @@ The document aims to guide you through:
 * **Receiving** VDLM2 data with [`vdlm2dec`](https://github.com/TLeconte/vdlm2dec)/[`docker-vdlm2dec`](https:/github.com/sdre-enthusiasts/docker-vdlm2dec) or [`dumpvdl2`](https://github.com/szpajder/dumpvdl2)/[`docker-dumpvdl2`](https:/github.com/sdre-enthusiasts/docker-dumpvdl2)
 * **Receiving** HFDL data with [`dumphfdl`](https://github.com/szpajder/dumphfdl)/[`docker-dumphfdl`](https:/github.com/sdre-enthusiasts/docker-dumphfdl)
 * **Receiving** SATCOM data.
-* **Feeding** data to online services, such as [`airframes`](airframes.io)
+* **Feeding** data to online services, such as [`airframes`](airframes.io) via [`acars_router`](https://github.com/sdre-enthusiasts/acars_router)
 * **Displaying** received data locally using [`ACARS Hub`](https://github.com/sdre-enthusiasts/docker-acarshub)


### PR DESCRIPTION
Change to reference # to talk about acars guide. Pointed to #acars-guide rather than adsb-bitbook [sic] - aim to avoid confusion between git books
Added mention of feeding airframes.io via acars router