### PR TITLE
chore(flake/nixpkgs): `b12141ef` -> `0726a0ec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -81,11 +81,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776548001,
-        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
+        "lastModified": 1776877367,
+        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
+        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
| [`a18e9fc2`](https://github.com/NixOS/nixpkgs/commit/a18e9fc25b1993d0c52f2cb3fe089ca91e09a78a) | `` chameleon-cli: 2.1.0-unstable-2026-04-06 -> 2.1.0-unstable-2026-04-19 ``                            |
| [`145bde70`](https://github.com/NixOS/nixpkgs/commit/145bde70a8386a97f4db175ab285b3385f280202) | `` pdk-ciel: 2.4.0 -> 2.4.1 ``                                                                         |
| [`7138b264`](https://github.com/NixOS/nixpkgs/commit/7138b26451e6ccb06b62884ce76edb46e358df75) | `` linux_6_12: 6.12.82 -> 6.12.83 ``                                                                   |
| [`0b01c28e`](https://github.com/NixOS/nixpkgs/commit/0b01c28e67a1a33bf0e13db453a0563c4fc56f49) | `` linux_6_18: 6.18.23 -> 6.18.24 ``                                                                   |
| [`28ed039c`](https://github.com/NixOS/nixpkgs/commit/28ed039c78a6feb946d5111f9e40f72ac3418221) | `` linux_6_19: 6.19.13 -> 6.19.14 ``                                                                   |
| [`a9d60f3c`](https://github.com/NixOS/nixpkgs/commit/a9d60f3c4dddfbba6ec759e5e29a1c32bdf6fa82) | `` linux_7_0: 7.0 -> 7.0.1 ``                                                                          |
| [`f666e9f8`](https://github.com/NixOS/nixpkgs/commit/f666e9f83681577480b6e04b6a47c2d29e72d4f1) | `` nixos-rebuild-ng: don't assert on exact order of calls ``                                           |
| [`9c2d68b4`](https://github.com/NixOS/nixpkgs/commit/9c2d68b46a131c9b2155d110b1bf9a268838cfe0) | `` sequoia-git: 0.5.0 -> 0.6.0 ``                                                                      |
| [`9880f9dd`](https://github.com/NixOS/nixpkgs/commit/9880f9dd708dcf8bb10e496b80117a6390eb5033) | `` nixos-init: fix example of extraBin ``                                                              |
| [`e8ce29b7`](https://github.com/NixOS/nixpkgs/commit/e8ce29b7561372469521b6573be2848c860c2101) | `` node-gyp: 12.2.0 -> 12.3.0 ``                                                                       |
| [`0f8fa653`](https://github.com/NixOS/nixpkgs/commit/0f8fa65370f4e48f3e20070bdad911642edeba53) | `` kdsingleapplication: 1.2.0 -> 1.2.1 ``                                                              |
| [`5e238ea6`](https://github.com/NixOS/nixpkgs/commit/5e238ea68de463401f7cc5242796bc52fbf46801) | `` lomiri-qt6.lomiri-ui-toolkit: Fix Qt 6.11 compatibility ``                                          |
| [`acdb2811`](https://github.com/NixOS/nixpkgs/commit/acdb28118b1da5e93c39da702c0afbd73483181a) | `` release-checks: fix eval error ``                                                                   |
| [`d8ed0dac`](https://github.com/NixOS/nixpkgs/commit/d8ed0dac72d4bc1dff141dc869484cbdfde1d717) | `` windsurf: 1.9600.41 -> 2.0.67 ``                                                                    |
| [`c9a17b85`](https://github.com/NixOS/nixpkgs/commit/c9a17b8561bb28dd6ff4025c20c939c578bf9efd) | `` python3Packages.python-opendata-transport: 0.5.0 -> 0.6.2 ``                                        |
| [`292a2ca7`](https://github.com/NixOS/nixpkgs/commit/292a2ca72130edb4722011b6151a410bb289097d) | `` python3Packages.rns: 1.1.6 -> 1.1.8 ``                                                              |
| [`50c402e1`](https://github.com/NixOS/nixpkgs/commit/50c402e168781e573aabd1558c53fe5395a5ef85) | `` python3Packages.pyexploitdb: 0.3.22 -> 0.3.23 ``                                                    |
| [`a310d76e`](https://github.com/NixOS/nixpkgs/commit/a310d76e854f386ab168e6975a4bcf67f47568b0) | `` python3Packages.pontos: 26.4.0 -> 26.4.1 ``                                                         |
| [`c35841dc`](https://github.com/NixOS/nixpkgs/commit/c35841dcb519fa8ced63d78a0e0e677947d76cac) | `` python3Packages.msgraph-sdk: 1.55.0 -> 1.56.0 ``                                                    |
| [`3311656d`](https://github.com/NixOS/nixpkgs/commit/3311656df635ba451b328db454271b6cab00e4da) | `` python3Packages.meilisearch: 0.40.0 -> 0.41.0 ``                                                    |
| [`29a4dda4`](https://github.com/NixOS/nixpkgs/commit/29a4dda466a10937221d2c765cd8524c996daddc) | `` python3Packages.mitogen: 0.3.45 -> 0.3.47 ``                                                        |
| [`9c65809e`](https://github.com/NixOS/nixpkgs/commit/9c65809ea27ead53f81c5c50e60e7ae071bf6f55) | `` checkip: 0.50.0 -> 0.53.0 ``                                                                        |
| [`69b47b5a`](https://github.com/NixOS/nixpkgs/commit/69b47b5a5f0a723dfedfba41cf0dc3fdf988296e) | `` python3Packages.boto3-stubs: 1.42.92 -> 1.42.93 ``                                                  |
| [`3ed5bd7d`](https://github.com/NixOS/nixpkgs/commit/3ed5bd7db8e2e20186f18f98df149718680848b0) | `` python3Packages.mypy-boto3-snowball: 1.42.3 -> 1.42.93 ``                                           |
| [`a6077d0e`](https://github.com/NixOS/nixpkgs/commit/a6077d0ee5d2334995e63d2586857d7e3b57da4a) | `` python3Packages.mypy-boto3-sagemaker: 1.42.91 -> 1.42.93 ``                                         |
| [`cd484d02`](https://github.com/NixOS/nixpkgs/commit/cd484d02e7d26650810f71a4d3991268b0dfadb1) | `` python3Packages.mypy-boto3-network-firewall: 1.42.3 -> 1.42.93 ``                                   |
| [`ae462410`](https://github.com/NixOS/nixpkgs/commit/ae4624103e723569a0a64f4bc9b347952fda68b5) | `` python3Packages.mypy-boto3-marketplace-entitlement: 1.42.58 -> 1.42.93 ``                           |
| [`50c427d1`](https://github.com/NixOS/nixpkgs/commit/50c427d1816b19a68d92ce941aae8c92bb42badb) | `` python3Packages.mypy-boto3-gamelift: 1.42.82 -> 1.42.93 ``                                          |
| [`89d07726`](https://github.com/NixOS/nixpkgs/commit/89d0772670971b5d77f5708f8a3e3c585759faec) | `` python3Packages.mypy-boto3-compute-optimizer: 1.42.3 -> 1.42.93 ``                                  |
| [`25f9f10f`](https://github.com/NixOS/nixpkgs/commit/25f9f10f1a6c3f143ebfca8abd4ea1cbba16f594) | `` python3Packages.mypy-boto3-comprehendmedical: 1.42.3 -> 1.42.93 ``                                  |
| [`a54697ed`](https://github.com/NixOS/nixpkgs/commit/a54697edffb3e7d968d542a6a8644f051ca32841) | `` python3Packages.mypy-boto3-cognito-idp: 1.42.90 -> 1.42.93 ``                                       |
| [`3f82d86b`](https://github.com/NixOS/nixpkgs/commit/3f82d86b724a06a7c9a1b4f73a98d7b90a0f791e) | `` python3Packages.iamdata: 0.1.202604211 -> 0.1.202604221 ``                                          |
| [`0507650e`](https://github.com/NixOS/nixpkgs/commit/0507650e7a69b6560854e55b7343ba0f130104e6) | `` python3Packages.publicsuffixlist: 1.0.2.20260417 -> 1.0.2.20260422 ``                               |
| [`72a7a929`](https://github.com/NixOS/nixpkgs/commit/72a7a9299b87470696518e3f05724526ddf518d6) | `` python3Packages.tencentcloud-sdk-python: 3.1.82 -> 3.1.83 ``                                        |
| [`4736df67`](https://github.com/NixOS/nixpkgs/commit/4736df67c936f8d5d51dc3cef76bd6e87365ac22) | `` libretro.desmume2015: 0-unstable-2022-04-05 -> 0-unstable-2026-04-20 ``                             |
| [`e23ad3bd`](https://github.com/NixOS/nixpkgs/commit/e23ad3bd2739af8ac41d5338fb389029f551cde9) | `` pkgs-lib/formats: switch toml generator from yj to go-toml (jsontoml) ``                            |
| [`d5551849`](https://github.com/NixOS/nixpkgs/commit/d5551849a5cc759afc706f87feef4a3f28d3ac6a) | `` go-toml: drop erroneous allowGoReference ``                                                         |
| [`32c7a5e0`](https://github.com/NixOS/nixpkgs/commit/32c7a5e0469e220b716188d4cc16aff7f143a7d1) | `` pkgs-lib/formats: add regression tests for toml generator ``                                        |
| [`abd0e4ab`](https://github.com/NixOS/nixpkgs/commit/abd0e4abd9990871cdf7edd8e1e8944001bedb5a) | `` dprint-plugins.dprint-plugin-biome: 0.12.7 -> 0.12.8 ``                                             |
| [`74f0d69a`](https://github.com/NixOS/nixpkgs/commit/74f0d69a4bc98f616c52fbe9f74dcab9a81d7090) | `` qdjango: Fix tests ``                                                                               |
| [`e0a13710`](https://github.com/NixOS/nixpkgs/commit/e0a137109d1835230581030ac4c520e5ab6b8e65) | `` libretro.parallel-n64: 0-unstable-2025-12-04 -> 0-unstable-2026-04-20 ``                            |
| [`1d6c5f71`](https://github.com/NixOS/nixpkgs/commit/1d6c5f71f5028efef01dfb3ddea6922afa338022) | `` squeezelite: 2.0.0.1561 -> 2.0.0.1563 ``                                                            |
| [`efb2bfaf`](https://github.com/NixOS/nixpkgs/commit/efb2bfafc54fb6db67e3a49e8cd5e638ee57e20a) | `` apfel-llm: init at 1.0.5 ``                                                                         |
| [`296f6616`](https://github.com/NixOS/nixpkgs/commit/296f66161ac2688f34472da6d85a33556c3e7b2b) | `` kdePackages.spectacle: backport tesseract linking fix for OCR ``                                    |
| [`0c46d3de`](https://github.com/NixOS/nixpkgs/commit/0c46d3dedbab873954355487c045363ea16b96ba) | `` gemini-cli: 0.38.1 -> 0.38.2 ``                                                                     |
| [`a6d58044`](https://github.com/NixOS/nixpkgs/commit/a6d58044b192d2ca2835c8d5979cf222eca22f4f) | `` sendspin-go: 1.2.0 -> 1.5.0 ``                                                                      |
| [`dd3ce2f8`](https://github.com/NixOS/nixpkgs/commit/dd3ce2f81964d670824a9f605b3ff937440a0de3) | `` python3Packages.hueble: 2.2.1 -> 2.2.2 ``                                                           |
| [`2321e430`](https://github.com/NixOS/nixpkgs/commit/2321e43066c3bdfaa71e0a042e801ae1208bda1f) | `` python3Packages.scooby: 0.11.0 -> 0.11.1 ``                                                         |
| [`16c855b0`](https://github.com/NixOS/nixpkgs/commit/16c855b0cce1c93ec68b30964307f8f0168b33ac) | `` lomiri.lomiri-ui-toolkit: Fix FTBFS after qtbase changes ``                                         |
| [`b2e3d337`](https://github.com/NixOS/nixpkgs/commit/b2e3d337fa70eaad61745072442a13a86e6f65ba) | `` sbb-tui: init at 1.13.4 ``                                                                          |
| [`09b73830`](https://github.com/NixOS/nixpkgs/commit/09b73830a954e208d22808c86caa948ecbabc950) | `` vivaldi: 7.9.3970.50 -> 7.9.3970.55 ``                                                              |
| [`341840d4`](https://github.com/NixOS/nixpkgs/commit/341840d4f4f6b77673c185e5bc1505269ae7fdb0) | `` rage: 0.11.1 -> 0.11.2 ``                                                                           |
| [`297395e2`](https://github.com/NixOS/nixpkgs/commit/297395e26830a5c3443bd69e8215ea5f556ef3a4) | `` pphack: 0.1.2 -> 0.1.3 ``                                                                           |
| [`0b6942ce`](https://github.com/NixOS/nixpkgs/commit/0b6942cecb98edc60263f00934f0060688f208f3) | `` yq-go: 4.52.5 -> 4.53.2 ``                                                                          |
| [`ef67b11a`](https://github.com/NixOS/nixpkgs/commit/ef67b11ab01b16f17454de78427dba482a1420c4) | `` figtree: output webfonts ``                                                                         |
| [`070f0e9c`](https://github.com/NixOS/nixpkgs/commit/070f0e9c5133b7c0ae83ef108ed138dea801deeb) | `` figtree: add ners to maintainers ``                                                                 |
| [`dd2849e5`](https://github.com/NixOS/nixpkgs/commit/dd2849e56e7de93ffc7d8ba37922443846a9a8e5) | `` fastfetchMinimal: 2.61.0 -> 2.62.0 ``                                                               |
| [`99084a00`](https://github.com/NixOS/nixpkgs/commit/99084a00af6d3b9ea4c3126df6665860d3954f82) | `` qbz: 1.2.7 -> 1.2.8 ``                                                                              |
| [`a39a8d1c`](https://github.com/NixOS/nixpkgs/commit/a39a8d1cb19f1e31c8ae7ea0038c60b8f771d682) | `` libretro.virtualjaguar: 0-unstable-2026-04-03 -> 0-unstable-2026-04-16 ``                           |
| [`c7a407e6`](https://github.com/NixOS/nixpkgs/commit/c7a407e641395907463199676e46b06cafd09d42) | `` amp-cli: 0.0.1776125492-g5cb0c2 -> 0.0.1776834056-gfb3ba0 ``                                        |
| [`c9974531`](https://github.com/NixOS/nixpkgs/commit/c997453117d4303c2483c85c5cb3283b495cd6b2) | `` libretro.quicknes: 0-unstable-2026-03-31 -> 0-unstable-2026-04-20 ``                                |
| [`4f9b44a2`](https://github.com/NixOS/nixpkgs/commit/4f9b44a2968c9397d7b09fdf5fbf315259040bb0) | `` vivify: 0.13.0 -> 0.14.0 ``                                                                         |
| [`347c91ef`](https://github.com/NixOS/nixpkgs/commit/347c91efe7187f37a6ff948977c76e30d3084e7a) | `` usage: 3.2.0 -> 3.2.1 ``                                                                            |
| [`289c6b8e`](https://github.com/NixOS/nixpkgs/commit/289c6b8e04b47636325bfad71ca3b60904fcd5ec) | `` lemmy-server: 0.19.17 -> 0.19.18 ``                                                                 |
| [`bae44db9`](https://github.com/NixOS/nixpkgs/commit/bae44db9b3dd24d8f84acdc6d448fd3042f8b581) | `` libretro.snes9x2002: 0-unstable-2026-03-31 -> 0-unstable-2026-04-20 ``                              |
| [`4ee352eb`](https://github.com/NixOS/nixpkgs/commit/4ee352eb37f6168ae39171cb4be72262223452b5) | `` remnote: 1.25.7 -> 1.25.19 ``                                                                       |
| [`a0aa1482`](https://github.com/NixOS/nixpkgs/commit/a0aa1482aca00ee547092792415f2689f32c4a3e) | `` veroroute: 2.39 -> 2.40 ``                                                                          |
| [`b492fa6e`](https://github.com/NixOS/nixpkgs/commit/b492fa6e4248758c303d05ed9c642f10e1cb61a9) | `` firebase-tools: 15.14.0 -> 15.15.0 ``                                                               |
| [`2e3f3a18`](https://github.com/NixOS/nixpkgs/commit/2e3f3a185cce1d77b21e374f5931a7a75824f749) | `` go-httpbin: 2.22.0 -> 2.22.1 ``                                                                     |
| [`5507fb53`](https://github.com/NixOS/nixpkgs/commit/5507fb53de9d3a6fda9e1077fda34439050c6825) | `` clorinde: 1.4.0 -> 1.4.1 ``                                                                         |
| [`7b210c5c`](https://github.com/NixOS/nixpkgs/commit/7b210c5c8c124692c0ca70f9d7a4aa10d09f557d) | `` terminalmap: init at 0.1.0 ``                                                                       |
| [`fce3b0f4`](https://github.com/NixOS/nixpkgs/commit/fce3b0f4f20d9f1611c01608d91c32b26819157c) | `` python3Packages.agentic-threat-hunting-framework: 0.11.1 -> 0.11.2 ``                               |
| [`8cf6a228`](https://github.com/NixOS/nixpkgs/commit/8cf6a228cfc272222b861d843bc57b23a985f391) | `` terraform-providers.grafana_grafana: 4.31.0 -> 4.31.3 ``                                            |
| [`8d0edb36`](https://github.com/NixOS/nixpkgs/commit/8d0edb362ce29c90f9f969b794f51e7b13de333a) | `` libretro.gpsp: 0-unstable-2026-03-31 -> 0-unstable-2026-04-20 ``                                    |
| [`c9561198`](https://github.com/NixOS/nixpkgs/commit/c9561198f9ed6b91c801940eed4285cfca7dcb79) | `` zed-editor: 0.232.2 -> 0.232.3 ``                                                                   |
| [`345e2b56`](https://github.com/NixOS/nixpkgs/commit/345e2b56e5b4ad8b881e77bcdef41dbd3f768057) | `` hanko: 0.5.4 -> 1.1.2 ``                                                                            |
| [`64bf10f4`](https://github.com/NixOS/nixpkgs/commit/64bf10f4a643e2bea1da23d50fd1aeddfbf0a97c) | `` python3Packages.aioghost: 0.4.10 -> 0.4.11 ``                                                       |
| [`7e9d324f`](https://github.com/NixOS/nixpkgs/commit/7e9d324fd316382f22f8b510131d68fdaa8a2891) | `` terraform-providers.ciscodevnet_aci: 2.18.0 -> 2.19.0 ``                                            |
| [`93783ba3`](https://github.com/NixOS/nixpkgs/commit/93783ba3fd26b03438b5976587cd7494a2fd7a95) | `` maintainers: update email for hekazu ``                                                             |
| [`bffd5ff0`](https://github.com/NixOS/nixpkgs/commit/bffd5ff06f3ad78c357b652366dd764e588d6641) | `` libretro.mame2003-plus: 0-unstable-2026-04-08 -> 0-unstable-2026-04-14 ``                           |
| [`b2bda141`](https://github.com/NixOS/nixpkgs/commit/b2bda141a448e246d70209c75dd3882091522890) | `` phpstan: 2.1.47 -> 2.1.51 ``                                                                        |
| [`1eac2470`](https://github.com/NixOS/nixpkgs/commit/1eac2470b951ae05779cab0fda0861a9c760b936) | `` terraform-providers.hashicorp_awscc: 1.79.0 -> 1.80.0 ``                                            |
| [`c5e1229e`](https://github.com/NixOS/nixpkgs/commit/c5e1229e44b7eb16a058ea823675492d4d944bcd) | `` factoriolab: 3.18.2 -> 3.19.2 ``                                                                    |
| [`d210d779`](https://github.com/NixOS/nixpkgs/commit/d210d779a2cc2cc3d5776ff4ec501eb223290f58) | `` rns: 1.1.6 -> 1.1.8 ``                                                                              |
| [`cc90ca5c`](https://github.com/NixOS/nixpkgs/commit/cc90ca5c7cadda837ddc5a66bbb15f482c870364) | `` scip-go: 0.1.26 -> 0.2.1 ``                                                                         |
| [`616d79ee`](https://github.com/NixOS/nixpkgs/commit/616d79ee61b46315a00084f13ce75fc2f43bce45) | `` python3Packages.taxi: 6.3.2 -> 6.3.3 ``                                                             |
| [`9f00f21f`](https://github.com/NixOS/nixpkgs/commit/9f00f21f624a1d41adb3eca2486f256863063451) | `` vscode-extensions.vue.volar: 3.2.6 -> 3.2.7 ``                                                      |
| [`e1df4693`](https://github.com/NixOS/nixpkgs/commit/e1df469313d2febee13d13316d7f25d4b77e0a11) | `` trufflehog: 3.94.3 -> 3.95.1 ``                                                                     |
| [`787484c3`](https://github.com/NixOS/nixpkgs/commit/787484c39e0b9ed5c8f3fc408bd391f2d65707cd) | `` tfswitch: 1.16.0 -> 1.17.0 ``                                                                       |
| [`35a4d856`](https://github.com/NixOS/nixpkgs/commit/35a4d856b1df3f3277b3b415dea3f512b4ea9376) | `` matrix-alertmanager-receiver: 2026.4.1 -> 2026.4.15 ``                                              |
| [`58b201a5`](https://github.com/NixOS/nixpkgs/commit/58b201a5e9a34c81473ba83abd6f7827d8e75b71) | `` high-tide: 1.3.0 -> 1.3.1 ``                                                                        |
| [`4cec3122`](https://github.com/NixOS/nixpkgs/commit/4cec3122850f3aa592b04648c1088268bc6144a6) | `` nixos-rebuild-ng: refactor test_upgrade_channels ``                                                 |
| [`6888cfed`](https://github.com/NixOS/nixpkgs/commit/6888cfed7a5ea57e85d4f4cabcfa587d772367ee) | `` python3Packages.hdate: 1.1.2 -> 1.2.1 ``                                                            |
| [`94336a5b`](https://github.com/NixOS/nixpkgs/commit/94336a5bc792df6c286494e0e38907051e4e7186) | `` python3Packages.particle: 0.26.1 -> 0.26.2 ``                                                       |
| [`7a2bf503`](https://github.com/NixOS/nixpkgs/commit/7a2bf503e37402a3255c45f63bcd0871c0bfa68c) | `` pixi: 0.67.0 -> 0.67.1 ``                                                                           |
| [`2c7f0d79`](https://github.com/NixOS/nixpkgs/commit/2c7f0d79701976cc68481e6ed23e245e860da2b1) | `` nixos-rebuild-ng: mock pathlib.Path.exists in test_upgrade_channels ``                              |
| [`da2b18b8`](https://github.com/NixOS/nixpkgs/commit/da2b18b8c34aa0fe2d59ad28cc9c32f619c4eb35) | `` python3Packages.distrax: 0.1.7 -> 0.1.8 ``                                                          |
| [`920b1f60`](https://github.com/NixOS/nixpkgs/commit/920b1f60269717c70afc73d37d1b3b02289640c7) | `` katawa-shoujo-re-engineered: reduce size by using renpyMinimal ``                                   |
| [`f57cb0b7`](https://github.com/NixOS/nixpkgs/commit/f57cb0b761c15a9b1463b0327dbb0b05cadb5e62) | `` renpyMinimal: init ``                                                                               |
| [`36837cc6`](https://github.com/NixOS/nixpkgs/commit/36837cc62c9366c25b2eb2ee495b50b7ef9290a1) | `` renpy: 8.4.1.25072401 -> 8.5.2.26010301-unstable-2026-03-27; add ulysseszhan as maintainer ``       |
| [`a2dd5575`](https://github.com/NixOS/nixpkgs/commit/a2dd557503bbe72fe1db20e44a518da5fc926910) | `` pinact: 3.8.0 -> 3.9.0 ``                                                                           |
| [`ed1b90fb`](https://github.com/NixOS/nixpkgs/commit/ed1b90fb228dd046d39f931a4befb4f7d338ccd2) | `` python3Packages.nuclear: 2.7.0 -> 2.7.1 ``                                                          |
| [`d0ef07c2`](https://github.com/NixOS/nixpkgs/commit/d0ef07c257152c78a3fd729365d4ffe22e57e2ee) | `` vunnel: 0.55.3 -> 0.56.0 ``                                                                         |
| [`a5ac3441`](https://github.com/NixOS/nixpkgs/commit/a5ac34418634f93cb59bb7d9da2410ce611282e0) | `` atlantis: add tebriel as maintainer ``                                                              |
| [`752f6352`](https://github.com/NixOS/nixpkgs/commit/752f6352e813e06e4aadab5ff5063293c2ba748e) | `` libretro.smsplus-gx: 0-unstable-2026-03-31 -> 0-unstable-2026-04-20 ``                              |
| [`ee762292`](https://github.com/NixOS/nixpkgs/commit/ee76229216477d8460fe5f4f9dc7b000c5f14350) | `` terraform-providers.digitalocean_digitalocean: 2.81.0 -> 2.84.1 ``                                  |
| [`cb4dce26`](https://github.com/NixOS/nixpkgs/commit/cb4dce2673365ec57060db923c15397cdcc66929) | `` erlang_28: 28.4.2 -> 28.4.3 ``                                                                      |
| [`232b4131`](https://github.com/NixOS/nixpkgs/commit/232b4131925e21bfae5caf41a49b726f10f9c5a3) | `` erlang_27: 27.3.4.10 -> 27.3.4.11 ``                                                                |
| [`7fed7a40`](https://github.com/NixOS/nixpkgs/commit/7fed7a400d3605d8a390607eaabda0fba00d900f) | `` nixos/systemd/initrd: fix modprobe ``                                                               |
| [`c6c8fdcb`](https://github.com/NixOS/nixpkgs/commit/c6c8fdcb6164433e05c0e443580647773ad055da) | `` cargo-xwin: 0.21.5 -> 0.22.0 ``                                                                     |
| [`3d4e9bf9`](https://github.com/NixOS/nixpkgs/commit/3d4e9bf91fc5cef6b661507139aa48e518c68e1c) | `` camunda-modeler: 5.46.0 -> 5.46.1 ``                                                                |
| [`487431d6`](https://github.com/NixOS/nixpkgs/commit/487431d6b0755a0cb3eaad632477e41434117e33) | `` radioboat: 0.5.0 -> 0.6.0 ``                                                                        |
| [`bba72ec6`](https://github.com/NixOS/nixpkgs/commit/bba72ec61da26cc7bd858fc7ce3e1554776f9d8d) | `` radioboat: 0.3.0 -> 0.5.0 ``                                                                        |
| [`388e5fcb`](https://github.com/NixOS/nixpkgs/commit/388e5fcb501fb241ad4957fb06157fd477e9de8b) | `` urx: init at 0.9.0 ``                                                                               |
| [`1beeb6bc`](https://github.com/NixOS/nixpkgs/commit/1beeb6bcafc980c723469ddd8f382fc783ffea82) | `` emacs: lift withXwidgets constraint ``                                                              |
| [`e1b49e16`](https://github.com/NixOS/nixpkgs/commit/e1b49e169133625954b69f0c046406ba9965c358) | `` emacs: remove meta.knownVulnerabilities of Emacs <30 ``                                             |
| [`98b10a4b`](https://github.com/NixOS/nixpkgs/commit/98b10a4b9cc54e749b3edca6bfc3a99a201ea89b) | `` ggml: 0.9.11 -> 0.10.0 ``                                                                           |
| [`4879decb`](https://github.com/NixOS/nixpkgs/commit/4879decbceb9d5b24437cf50d2c4068b8bc49cf5) | `` python3Packages.wagtail-modeladmin: 2.2.0 -> 2.3.0 ``                                               |
| [`4bab2aa6`](https://github.com/NixOS/nixpkgs/commit/4bab2aa6af24da00866d21ca04ce6c181977f3d1) | `` cudaPackages.libcuobjclient: init at 1.0.0.26 ``                                                    |
| [`984c7fa4`](https://github.com/NixOS/nixpkgs/commit/984c7fa4c0ccc01402023c9e3090c2034299c132) | `` python3Packages.mediafile: 0.16.0 -> 0.16.2 ``                                                      |
| [`7c34ac47`](https://github.com/NixOS/nixpkgs/commit/7c34ac47698ab30ef083ad712924799d1eb7dbb5) | `` nixos/acme: fix incorrectly using mkRenamedOptionModule in submodule ``                             |
| [`bb53f67b`](https://github.com/NixOS/nixpkgs/commit/bb53f67be3c3f285d0c717664d0b8165a32a4eb1) | `` speakersafetyd: 1.1.2-unstable-2026-03-28 -> 2.0.0 ``                                               |
| [`88bb1d3b`](https://github.com/NixOS/nixpkgs/commit/88bb1d3b48b86cfffc832a5a51141295f08fa57c) | `` amneziawg-go: 0.2.16 -> 0.2.17 ``                                                                   |
| [`ea18c327`](https://github.com/NixOS/nixpkgs/commit/ea18c327cb53a99be5c3dded9a8efc8957c1cf27) | `` open-webui: 0.8.12 -> 0.9.1 ``                                                                      |
| [`204f457b`](https://github.com/NixOS/nixpkgs/commit/204f457bd374bf7d59f9051d0b3e4484c30b49d3) | `` fg-virgil: 0.18.0 -> 0.18.1 ``                                                                      |
| [`30acccdc`](https://github.com/NixOS/nixpkgs/commit/30acccdc33df21ab640e0b90bae195d2b101ab29) | `` excalifont: 0.18.0 -> 0.18.1 ``                                                                     |
| [`1a9bbc06`](https://github.com/NixOS/nixpkgs/commit/1a9bbc066fd655a9460946c308748f42e061b4c0) | `` neovim: check for pnames when asserting if two treesitters are installed ``                         |
| [`205b28d2`](https://github.com/NixOS/nixpkgs/commit/205b28d2ec70c7f05592b71c3c67a265a89d75a3) | `` nixos/programs/command-not-found: fix eval ``                                                       |
| [`8956bf1d`](https://github.com/NixOS/nixpkgs/commit/8956bf1d4f39e8c187d86534ed41f9c44adbeefc) | `` glaze: 7.3.3 -> 7.4.0 ``                                                                            |
| [`17773e7f`](https://github.com/NixOS/nixpkgs/commit/17773e7fa71a0f37209b7b6953013a9a5143ca79) | `` nixos/tests/switch-test: cover user-unit migration to NixOS ``                                      |
| [`5cc82c49`](https://github.com/NixOS/nixpkgs/commit/5cc82c4922f8da8223f88ae6d15c85b69ab85bd0) | `` switch-to-configuration-ng: handle user units migrating to NixOS ``                                 |
| [`106c49d2`](https://github.com/NixOS/nixpkgs/commit/106c49d2e442ddb3b1fb164daa00a5f722a01e0f) | `` nixos/tests/switch-test: cover user-unit restart on switch ``                                       |
| [`2ff37e40`](https://github.com/NixOS/nixpkgs/commit/2ff37e40e07672518f0e13c6be3ff0c0a74ea736) | `` switch-to-configuration-ng: restart changed user units on switch ``                                 |
| [`5e22ad20`](https://github.com/NixOS/nixpkgs/commit/5e22ad20daa527c0592d8f458102e42f2cc3365e) | `` switch-to-configuration-ng: parameterise unit handling over UnitScope ``                            |
| [`5e4c815e`](https://github.com/NixOS/nixpkgs/commit/5e4c815e269e24499626d1913cd09b0fe5efbc98) | `` switch-to-configuration-ng: extract unit comparison loop into helper ``                             |
| [`eee03121`](https://github.com/NixOS/nixpkgs/commit/eee031213ae6c53d282436baf0ab946dcc59924e) | `` apko: 1.2.3 -> 1.2.4 ``                                                                             |
| [`8a6e8eba`](https://github.com/NixOS/nixpkgs/commit/8a6e8ebac6978a75174d0edf910c3f924ebbd511) | `` passff-host: 1.2.4 -> 1.2.5 ``                                                                      |
| [`ffb2278d`](https://github.com/NixOS/nixpkgs/commit/ffb2278df4e40c670f79c08c9cb4e93bcf75f133) | `` passff-host: fix patches not working ``                                                             |
| [`8c3f0384`](https://github.com/NixOS/nixpkgs/commit/8c3f0384d261f6f3285de546f828a24fc979c471) | `` libretro.vice-x128: 0-unstable-2026-04-02 -> 0-unstable-2026-04-18 ``                               |
| [`de120248`](https://github.com/NixOS/nixpkgs/commit/de120248fcb5bdf24418406aa5af42e29fcb2ba1) | `` tomlc17: 260323 -> 260414 ``                                                                        |
| [`7582b98c`](https://github.com/NixOS/nixpkgs/commit/7582b98c85e5169758b1c77b980caf01e1a319ee) | `` forgejo-runner: 12.8.2 -> 12.9.0 ``                                                                 |
| [`5e41e0c4`](https://github.com/NixOS/nixpkgs/commit/5e41e0c468903562cb53b1b7b3e62e29734b72f8) | `` ruby_4_0: 4.0.2 -> 4.0.3 ``                                                                         |
| [`964cd433`](https://github.com/NixOS/nixpkgs/commit/964cd433d31b29f4917e41d77cbeeeba0a858828) | `` libretro.ppsspp: 0-unstable-2026-03-31 -> 0-unstable-2026-04-20 ``                                  |
| [`6f07baa4`](https://github.com/NixOS/nixpkgs/commit/6f07baa4f140cfc6d654515c5b6888652c8b54be) | `` cdncheck: 1.2.31 -> 1.2.32 ``                                                                       |
| [`639df78b`](https://github.com/NixOS/nixpkgs/commit/639df78bbdb60c46a37dd784b71371757e695cc7) | `` volanta: 1.16.4 -> 1.17.2 ``                                                                        |
| [`f1580208`](https://github.com/NixOS/nixpkgs/commit/f15802082e017d9f4d215541aec2cb16be38325a) | `` python3Packages.ansi2image: 0.1.4 -> 0.1.5 ``                                                       |
| [`de106f53`](https://github.com/NixOS/nixpkgs/commit/de106f53f2a91df6d4e61757b92e86f03f6966ac) | `` klipper: fix cross ``                                                                               |
| [`42b7c6b4`](https://github.com/NixOS/nixpkgs/commit/42b7c6b49a55664e7727c3c388e7d92dfd5da5b4) | `` postgresqlPackages.pgmq: 1.11.0 -> 1.11.1 ``                                                        |
| [`4898bd56`](https://github.com/NixOS/nixpkgs/commit/4898bd564e8625fdf0a96844190ef63401acb8b3) | `` libnvidia-container: remove katexochen from maintainers ``                                          |
| [`72236950`](https://github.com/NixOS/nixpkgs/commit/722369506bd88dc35121d2b5ee398fb2d5f718be) | `` envoy-bin: remove katexochen from maintainers ``                                                    |
| [`b028d2fb`](https://github.com/NixOS/nixpkgs/commit/b028d2fb5d45d18ff674281c5afbea3a150fc273) | `` cnspec: 13.4.1 -> 13.5.0 ``                                                                         |
| [`f9573cd5`](https://github.com/NixOS/nixpkgs/commit/f9573cd5a4c2dedf36e7812834ef5e8bf6406d53) | `` openbao: 2.5.2 -> 2.5.3 ``                                                                          |
| [`a9b648e7`](https://github.com/NixOS/nixpkgs/commit/a9b648e7b4359ec8beaa2c9a75313408b320e495) | `` python3Packages.python-youtube: 0.9.8 -> 0.9.9 ``                                                   |
| [`1a26dc15`](https://github.com/NixOS/nixpkgs/commit/1a26dc157852edddb64181ccfd01cf5570c990d3) | `` jsonschema-cli: 0.46.0 -> 0.46.2 ``                                                                 |
| [`d2d15a79`](https://github.com/NixOS/nixpkgs/commit/d2d15a791d1f2f53eef09cd4874825677a5a7595) | `` grafanaPlugins.grafana-clickhouse-datasource: 4.14.0 -> 4.15.0 ``                                   |
| [`83840085`](https://github.com/NixOS/nixpkgs/commit/8384008549523f32fd3524a2e2bf642d7754563a) | `` whoogle-search: 1.2.3 -> 1.2.4 ``                                                                   |
| [`83e45e01`](https://github.com/NixOS/nixpkgs/commit/83e45e019e4cf344c973ba23bf3497656d89f073) | `` passff-host: add nix-update-script ``                                                               |
| [`250e7133`](https://github.com/NixOS/nixpkgs/commit/250e7133b61135cbe875d230a017244ce19c8a95) | `` passff-host: use upstream codeberg source ``                                                        |
| [`d2c949d7`](https://github.com/NixOS/nixpkgs/commit/d2c949d725459d0dc2160f910b28cd2625c1d552) | `` nixos/dbus: switch default implementation to dbus-broker ``                                         |
| [`d3c143b6`](https://github.com/NixOS/nixpkgs/commit/d3c143b63fd6c31860632021ca18f7b57cf19e74) | `` pocket-tts: 1.1.1 -> 2.0.0 ``                                                                       |
| [`6d38dc14`](https://github.com/NixOS/nixpkgs/commit/6d38dc14a5417a98d269c09d43207b1585cfee77) | `` files-cli: 2.15.264 -> 2.15.274 ``                                                                  |
| [`383effce`](https://github.com/NixOS/nixpkgs/commit/383effceb85e6a1353f97e26b300bb108e480a1c) | `` kiro-cli: 1.29.8 -> 2.0.1 ``                                                                        |
| [`193b32f5`](https://github.com/NixOS/nixpkgs/commit/193b32f5b82877a3e0b8dbd1c0dd86bf8d5681ef) | `` ly: populate $out/etc directory with relevant files ``                                              |
| [`2dc4e421`](https://github.com/NixOS/nixpkgs/commit/2dc4e4218c51c07b27859f18d7b61081f93e6f7b) | `` cpeditor: 7.0.2 -> 7.1.1 ``                                                                         |
| [`8fc19990`](https://github.com/NixOS/nixpkgs/commit/8fc1999014f1dc231fbd59fea7e4cadc90f2de3b) | `` kustomize-sops: 4.4.0 -> 4.5.1 ``                                                                   |
| [`41d0f93f`](https://github.com/NixOS/nixpkgs/commit/41d0f93f9c1511e1faabb4db59021c49838332ff) | `` hermitcli: 0.50.2 -> 0.52.0 ``                                                                      |
| [`0cc949a5`](https://github.com/NixOS/nixpkgs/commit/0cc949a5e9aad63e762c627ee4174c6de37c4b06) | `` inputplumber: 0.76.0 -> 0.76.1 ``                                                                   |
| [`42e740fd`](https://github.com/NixOS/nixpkgs/commit/42e740fd1e53fa6694e75c5ba16f22ed1686db08) | `` enlightenment.evisum: 1.2.2 -> 1.2.3 ``                                                             |
| [`861fa36a`](https://github.com/NixOS/nixpkgs/commit/861fa36af2d740826ca18a7547bdc5f3a817d452) | `` ty: 0.0.31 -> 0.0.32 ``                                                                             |
| [`9df693bb`](https://github.com/NixOS/nixpkgs/commit/9df693bb04f689d48013acf9b10f214a0fc25f3d) | `` python3Packages.torchvision: 0.25.0 -> 0.26.0 ``                                                    |
| [`4aaae569`](https://github.com/NixOS/nixpkgs/commit/4aaae56905064f93d17cbccb3661bdcb4878c22a) | `` python3Packages.torchaudio-bin: 2.10.0 -> 2.11.0 ``                                                 |
| [`078e047e`](https://github.com/NixOS/nixpkgs/commit/078e047e45bb3839f7dd828f1f9b74dee9128891) | `` python3Packages.torch-bin: 2.10.0 -> 2.11.0 ``                                                      |
| [`7e68b605`](https://github.com/NixOS/nixpkgs/commit/7e68b6058c9b2398036321746a76c062c4d24035) | `` gibo: 3.0.20 -> 3.0.21 ``                                                                           |
| [`61730649`](https://github.com/NixOS/nixpkgs/commit/617306490cadd78d4c46ce93a7df4cced6e7cf7c) | `` Revert "nixos/prometheus-exporters: add socketOpts and use for node-exporter & postfix-exporter" `` |
| [`411c45ca`](https://github.com/NixOS/nixpkgs/commit/411c45caa46d0bdd95d0aa71f828a721a40a9a46) | `` itgmania: fix version string ``                                                                     |
| [`8bcc75c9`](https://github.com/NixOS/nixpkgs/commit/8bcc75c90a046d2692ee3bd72d1ad683cd945d9e) | `` itgmania: 1.2.0 -> 1.2.1 ``                                                                         |
| [`0179c485`](https://github.com/NixOS/nixpkgs/commit/0179c4859ca0618b1ee105b25ab4db15579f4ca7) | `` itgmaniaPackages: init ``                                                                           |
| [`569abbc2`](https://github.com/NixOS/nixpkgs/commit/569abbc27a329e66c7ee2d572ee89258d068dd19) | `` gh-poi: 0.16.4 -> 0.17.0 ``                                                                         |
| [`64756b5c`](https://github.com/NixOS/nixpkgs/commit/64756b5c046722cafaa1f77e62552b9f6ffc70eb) | `` geph: 0.2.93 -> 0.2.99 ``                                                                           |
| [`6761403a`](https://github.com/NixOS/nixpkgs/commit/6761403af74093e94048be9304473d88989dda6f) | `` python3Packages.nominatim-api: 5.3.1 -> 5.3.2 ``                                                    |
| [`d79fd851`](https://github.com/NixOS/nixpkgs/commit/d79fd8511c95cbe69bb1903f3d739ae146889f13) | `` lasuite-meet-frontend: 1.13.0 -> 1.14.0 ``                                                          |
| [`f7b16806`](https://github.com/NixOS/nixpkgs/commit/f7b16806810d95d2390975efed619fa4d7bd83ee) | `` lasuite-meet: 1.13.0 -> 1.14.0 ``                                                                   |
| [`14909ee0`](https://github.com/NixOS/nixpkgs/commit/14909ee04e7f6fd40f6de5b9d2c48d6065f8a110) | `` proton-pass-cli: 1.10.0 -> 2.0.0 ``                                                                 |
| [`5768e6bf`](https://github.com/NixOS/nixpkgs/commit/5768e6bfd60440f3c4a3a080111e457735f5242c) | `` routedns: 0.1.154 -> 0.1.155 ``                                                                     |
| [`1328896c`](https://github.com/NixOS/nixpkgs/commit/1328896c5e82f58a49ac3a16140bc36e870cc2b7) | `` opencloud.web: 6.1.0 -> 6.2.0 ``                                                                    |
| [`d0fd204a`](https://github.com/NixOS/nixpkgs/commit/d0fd204abc6088e93f286789b3248f2aa5fc919f) | `` opencloud: 6.0.0 -> 6.1.0 ``                                                                        |
| [`ac6db8ad`](https://github.com/NixOS/nixpkgs/commit/ac6db8ad30abf3e8c38ee77671336c2e974c0bd0) | `` netbird: 0.68.3 -> 0.69.0 ``                                                                        |
| [`f13e8095`](https://github.com/NixOS/nixpkgs/commit/f13e80952401a5258eb48cb372aaba85f33e1a59) | `` python3Packages.pysigma: 1.3.1 -> 1.3.2 ``                                                          |
| [`e46a42db`](https://github.com/NixOS/nixpkgs/commit/e46a42dbe96caf4dcd0ff2df9c9053de7c24dca0) | `` wily: fix build with gcc15 ``                                                                       |
| [`f7e88cbd`](https://github.com/NixOS/nixpkgs/commit/f7e88cbdb02d5a0e12eeb0505110179158977cab) | `` python3Packages.boto3-stubs: 1.42.91 -> 1.42.92 ``                                                  |
| [`37695aec`](https://github.com/NixOS/nixpkgs/commit/37695aecfa8c4b2a73d19d4ccb32a5d277edb7ca) | `` python3Packages.biocutils: 0.3.4 -> 0.4.0 ``                                                        |
| [`f1cc92d1`](https://github.com/NixOS/nixpkgs/commit/f1cc92d1cf4d40baa75cc863d233922953a08d8c) | `` python3Packages.mypy-boto3-location: 1.42.3 -> 1.42.92 ``                                           |
| [`75b30623`](https://github.com/NixOS/nixpkgs/commit/75b306236b3a9a77fadc0395b7d8d6d6467c2b2b) | `` python3Packages.mypy-boto3-kafka: 1.42.65 -> 1.42.92 ``                                             |
| [`3b643548`](https://github.com/NixOS/nixpkgs/commit/3b6435486f2430a1a058e7de886756a46f5b5f9b) | `` python3Packages.mypy-boto3-guardduty: 1.42.84 -> 1.42.92 ``                                         |
| [`a8b50ddb`](https://github.com/NixOS/nixpkgs/commit/a8b50ddb946629fb95d9b29d02032dd286066dfc) | `` python3Packages.mypy-boto3-ec2: 1.42.85 -> 1.42.92 ``                                               |
| [`e3d5fe07`](https://github.com/NixOS/nixpkgs/commit/e3d5fe0771fd56666bbb38c18f77623b28de5550) | `` python3Packages.iamdata: 0.1.202604201 -> 0.1.202604211 ``                                          |
| [`3561e605`](https://github.com/NixOS/nixpkgs/commit/3561e605f2f9c875d36d9388ec2ccb5739b494b1) | `` python3Packages.iamdata: 0.1.202604191 -> 0.1.202604201 ``                                          |
| [`1dbe65ec`](https://github.com/NixOS/nixpkgs/commit/1dbe65eccb92f1948936e4a15d1d4b2547556917) | `` python3Packages.tencentcloud-sdk-python: 3.1.81 -> 3.1.82 ``                                        |
| [`e047b195`](https://github.com/NixOS/nixpkgs/commit/e047b195cd4306886f2ecbc895b33bbf2714bd04) | `` python3Packages.tencentcloud-sdk-python: 3.1.80 -> 3.1.81 ``                                        |
| [`beb768ff`](https://github.com/NixOS/nixpkgs/commit/beb768ff7db4a6579661100f8784089745a51ee0) | `` kubedock: 0.21.0 -> 0.21.1 ``                                                                       |
| [`7e921473`](https://github.com/NixOS/nixpkgs/commit/7e9214739a972f5d354fb4211a966e615db3ef6e) | `` python3Packages.oslo-concurrency: 7.4.0 -> 7.4.1 ``                                                 |
| [`86f7df35`](https://github.com/NixOS/nixpkgs/commit/86f7df35e783f9e601afd39b008e95096ce04cf7) | `` vscode-extensions.vitest.explorer: 1.50.1 -> 1.50.2 ``                                              |
| [`f7784f5f`](https://github.com/NixOS/nixpkgs/commit/f7784f5f9b6146a797556c9ddd2113350b629a3e) | `` libretro.bsnes-mercury: 0-unstable-2024-10-21 -> 0-unstable-2026-04-20 ``                           |
| [`3c998b43`](https://github.com/NixOS/nixpkgs/commit/3c998b4305576bcbe7e85488c35b949e69307ab8) | `` kodiPackages.radioparadise: 2.3.0 -> 2.4.0 ``                                                       |
| [`eb1fe5f8`](https://github.com/NixOS/nixpkgs/commit/eb1fe5f888cab686fc939eae23dd2e3e921f3931) | `` codex: 0.121.0 -> 0.122.0 ``                                                                        |
| [`c8badd68`](https://github.com/NixOS/nixpkgs/commit/c8badd681eea4a9290c8aec32483002e4d63f050) | `` atlantis: 0.41.0 -> 0.42.0 ``                                                                       |
| [`3a3e1aa3`](https://github.com/NixOS/nixpkgs/commit/3a3e1aa3518d12affd784d00971ab4ab88ccd74b) | `` python3Packages.waterfurnace: 1.6.5 -> 1.7.1 ``                                                     |
| [`fdb7c095`](https://github.com/NixOS/nixpkgs/commit/fdb7c0953df27c72192c289fdb9571a37c146d59) | `` stackql: 0.10.421 -> 0.10.426 ``                                                                    |
| [`ba5acf32`](https://github.com/NixOS/nixpkgs/commit/ba5acf32c212f60b1e4b2a6f7ed1b9fb6b39a7ca) | `` python3Packages.disposable-email-domains: 0.0.169 -> 0.0.172 ``                                     |
| [`77cd91ec`](https://github.com/NixOS/nixpkgs/commit/77cd91ec44d569a1a2ba404a2227ff9b57a0b3db) | `` vscode-extensions.redhat.vscode-yaml: 1.21.0 -> 1.22.0 ``                                           |
| [`e61c9695`](https://github.com/NixOS/nixpkgs/commit/e61c96958d20c7ee7770235c2e020d6061574997) | `` python3Packages.django-treenode: 0.23.3 -> 0.24.0 ``                                                |
| [`76783642`](https://github.com/NixOS/nixpkgs/commit/767836426aef3f85424179fbb0a432ac09fdad9b) | `` mimir: 3.0.5 -> 3.0.6 ``                                                                            |
| [`d5f9f8f0`](https://github.com/NixOS/nixpkgs/commit/d5f9f8f0fb3b2d38cace68ddcc40eae105dcf5fd) | `` cherry-studio: 1.9.1 -> 1.9.2 ``                                                                    |
| [`4a5130b0`](https://github.com/NixOS/nixpkgs/commit/4a5130b0c2d4ed015f61d1fc6b278b9697d22ea6) | `` libretro.tic80: 0-unstable-2024-05-13 -> 0-unstable-2026-04-20 ``                                   |
| [`1d9db6ed`](https://github.com/NixOS/nixpkgs/commit/1d9db6ed9c778ab88183e4fbd5eebbe46ae79412) | `` python3Packages.modelcif: use finalAttrs pattern ``                                                 |
| [`aba162f2`](https://github.com/NixOS/nixpkgs/commit/aba162f224f4aa28a58fbb4de35627948f630704) | `` python3Packages.ihm: use finalAttrs pattern ``                                                      |
| [`eeb931fa`](https://github.com/NixOS/nixpkgs/commit/eeb931fa1894eb34df30ae4a8d51886a9b54e200) | `` python3Packages.modelcif: 1.6 -> 1.7 ``                                                             |
| [`da07e07a`](https://github.com/NixOS/nixpkgs/commit/da07e07a2b2952689083c87d4c5c4e0ba2b3aed0) | `` libretro.handy: 0-unstable-2026-03-31 -> 0-unstable-2026-04-20 ``                                   |
| [`8dd35a7b`](https://github.com/NixOS/nixpkgs/commit/8dd35a7b4d60de5d3bee5b79b9233bb7e976467d) | `` vscode-extensions.mkhl.shfmt: 1.5.1 -> 1.5.2 ``                                                     |
| [`3caab2ba`](https://github.com/NixOS/nixpkgs/commit/3caab2ba7d1d3398f3743b6bee2c1a57f31d929b) | `` terraform-providers.scaleway_scaleway: 2.71.0 -> 2.73.0 ``                                          |
| [`7264c947`](https://github.com/NixOS/nixpkgs/commit/7264c947e57a125bf67de269616d9480d924f4cd) | `` ssh-vault: 1.2.4 -> 1.2.6 ``                                                                        |
| [`b60cacf5`](https://github.com/NixOS/nixpkgs/commit/b60cacf51d6e17bea54475c9fec4505ac65ad2e8) | `` libretro.beetle-supergrafx: 0-unstable-2026-03-31 -> 0-unstable-2026-04-20 ``                       |
| [`5f088341`](https://github.com/NixOS/nixpkgs/commit/5f088341936f331edb87c39558551430bf155fe2) | `` dokieli: 0-unstable-2026-04-13 -> 0-unstable-2026-04-20 ``                                          |
| [`11698011`](https://github.com/NixOS/nixpkgs/commit/11698011196e006c53cdb59b551820ac37ef2e1b) | `` rio: 0.3.4 -> 0.3.11 ``                                                                             |
| [`10c2fea7`](https://github.com/NixOS/nixpkgs/commit/10c2fea737ee75202e5104113b1a5fdd8ba3994b) | `` zed-editor: add mjm as maintainer ``                                                                |
| [`88cb645b`](https://github.com/NixOS/nixpkgs/commit/88cb645b4e8405463148d5d8e7bf861f3d1bc709) | `` terraform-providers.kreuzwerker_docker: 4.1.0 -> 4.2.0 ``                                           |
| [`59d08226`](https://github.com/NixOS/nixpkgs/commit/59d08226c8abb8728d62692fd8a55817f8d50f88) | `` buildbox: 1.4.0 -> 1.4.4 ``                                                                         |
| [`498eb66e`](https://github.com/NixOS/nixpkgs/commit/498eb66e0924c94e7cc97423a9ff5d2b9e384f44) | `` libretro.beetle-saturn: 0-unstable-2026-01-12 -> 0-unstable-2026-04-20 ``                           |
| [`54ad0aa3`](https://github.com/NixOS/nixpkgs/commit/54ad0aa30302246153a474650dfe310dae7b8368) | `` wpsoffice-cn: 12.1.2.25838 -> 12.1.2.25882 for linux; 12.1.25205 -> 12.1.25867 for darwin ``        |
| [`a66b1465`](https://github.com/NixOS/nixpkgs/commit/a66b1465cfadf12fdc6511121a293a72cc99dff0) | `` nextdns: 1.46.0 -> 1.47.2 ``                                                                        |
| [`11a35cf9`](https://github.com/NixOS/nixpkgs/commit/11a35cf9d55b0dc4abc59fba85244212e9614ea9) | `` buck2: unstable-2025-12-01 -> unstable-2026-04-15 ``                                                |
| [`dc4b5922`](https://github.com/NixOS/nixpkgs/commit/dc4b59225c23f10842e0519d428e529a3708f391) | `` metacubexd: 1.244.2 -> 1.245.0 ``                                                                   |
| [`55ac0b09`](https://github.com/NixOS/nixpkgs/commit/55ac0b095a68d2c4ab568e10bdb101bd878196ab) | `` garnet: 1.1.1 -> 1.1.3 ``                                                                           |
| [`f4ab0042`](https://github.com/NixOS/nixpkgs/commit/f4ab0042f832acc74754253f8bb2b7b96d816a87) | `` libretro.gw: 0-unstable-2026-03-31 -> 0-unstable-2026-04-20 ``                                      |
| [`9077d445`](https://github.com/NixOS/nixpkgs/commit/9077d4459e29749f11f7fb8525eeecbacd327574) | `` kubevirt: 1.8.1 -> 1.8.2 ``                                                                         |
| [`c154494b`](https://github.com/NixOS/nixpkgs/commit/c154494be4581ec65f6640720701c1ed80cbe665) | `` terraform-providers.bpg_proxmox: 0.101.1 -> 0.103.0 ``                                              |
| [`ea8917d8`](https://github.com/NixOS/nixpkgs/commit/ea8917d843273ce7498a44b08b08c2fa9611d5b7) | `` arkenfox-userjs: 140.1 -> 144.0 ``                                                                  |
| [`c7f74c57`](https://github.com/NixOS/nixpkgs/commit/c7f74c5786fccddb764843a0a1f96a2539871162) | `` flashmq: 1.26.0 -> 1.26.1 ``                                                                        |
| [`90a2bf64`](https://github.com/NixOS/nixpkgs/commit/90a2bf64fe0a315c82aaeb105f54cdd806d43875) | `` vkmark: drop stale vulkan-headers 1.4.333 patch ``                                                  |
| [`d9bf6c7b`](https://github.com/NixOS/nixpkgs/commit/d9bf6c7b7acbd056f10f5e239ecac1db8923b95e) | `` python3Packages.kagglesdk: 0.1.18 -> 0.1.19 ``                                                      |
| [`9c582eb6`](https://github.com/NixOS/nixpkgs/commit/9c582eb64c22de3ad6910eac1cb4221a39092eb3) | `` python3Packages.ocrmypdf: 17.4.1 -> 17.4.2 ``                                                       |
| [`e2b3e0f1`](https://github.com/NixOS/nixpkgs/commit/e2b3e0f10dfe5fda53f82e0361b5cc0fb1f31371) | `` spicetify-cli: 2.43.1 -> 2.43.2 ``                                                                  |
| [`c9ea266f`](https://github.com/NixOS/nixpkgs/commit/c9ea266f6bffb62b720063371bf521441209f77d) | `` devbox: 0.17.1 -> 0.17.2 ``                                                                         |
| [`95eb232a`](https://github.com/NixOS/nixpkgs/commit/95eb232ad21836b54562e6a5d5a187a84d8a837e) | `` telegraf: 1.38.2 -> 1.38.3 ``                                                                       |
| [`c7bb8197`](https://github.com/NixOS/nixpkgs/commit/c7bb8197c4ad5c27187efa829edd4d4305af9638) | `` i2p: 2.11.0 -> 2.12.0 ``                                                                            |
| [`d30430e7`](https://github.com/NixOS/nixpkgs/commit/d30430e7eca9645a26e0e40000bcc31261aadc3c) | `` terraform: 1.14.8 -> 1.14.9 ``                                                                      |
| [`2ff9f7f4`](https://github.com/NixOS/nixpkgs/commit/2ff9f7f40db146c0a4e7953a02cfa043c52f7f13) | `` python3Packages.mcstatus: 13.0.1 -> 13.1.0 ``                                                       |
| [`4c69d2b4`](https://github.com/NixOS/nixpkgs/commit/4c69d2b4d6cc928c95512ff0fb6ed344aa57c450) | `` cargo-modules: 0.25.0 -> 0.26.0 ``                                                                  |
| [`62436c9c`](https://github.com/NixOS/nixpkgs/commit/62436c9cafd2ee0a6c45de38d2cfc03331158a2f) | `` python3Packages.pydeps: 3.0.2 -> 3.0.3 ``                                                           |
| [`b25ab369`](https://github.com/NixOS/nixpkgs/commit/b25ab36945529003c48c94f1fd5f52b604d9ed5d) | `` mapcache: 1.14.1 -> 1.16.0 ``                                                                       |
| [`417ac6c1`](https://github.com/NixOS/nixpkgs/commit/417ac6c12bd0db4d5576dedfaab3515311ddf6fd) | `` python3Packages.pyworxcloud: 6.3.2 -> 6.3.5 ``                                                      |
| [`658bf476`](https://github.com/NixOS/nixpkgs/commit/658bf4765e768402bfd7cc191e7ec319bf7d5bef) | `` python3Packages.paddleocr: 3.4.0 -> 3.4.1 ``                                                        |
| [`09ddb874`](https://github.com/NixOS/nixpkgs/commit/09ddb874c10822e5470ae314ef73591b50f2cfb0) | `` github: Serialize git worktree initialization ``                                                    |
| [`b8a46e4c`](https://github.com/NixOS/nixpkgs/commit/b8a46e4c86b065eb0938686272e6032ff2047c9d) | `` prometheus-knot-exporter: 3.5.3 -> 3.5.4 ``                                                         |
| [`051b9ea0`](https://github.com/NixOS/nixpkgs/commit/051b9ea0fba41f9638d2a74ede399165b8c4e8eb) | `` python3Packages.libknot: 3.5.3 -> 3.5.4 ``                                                          |
| [`f87b0188`](https://github.com/NixOS/nixpkgs/commit/f87b018849989a01b7d77d3188bd2e8f14edf8f9) | `` qownnotes: 26.4.14 -> 26.4.17 ``                                                                    |
| [`e706ba1d`](https://github.com/NixOS/nixpkgs/commit/e706ba1df444277893f55574d874102a9af25284) | `` python3Packages.typedunits: 0.0.1 -> 0.0.2 ``                                                       |
| [`be0b9e08`](https://github.com/NixOS/nixpkgs/commit/be0b9e089cd3e9a3dcb22b4915d1714ad22b9414) | `` cloudfox: 2.0.2 -> 2.0.3 ``                                                                         |
| [`ed8a5e78`](https://github.com/NixOS/nixpkgs/commit/ed8a5e787a9938ba34d50f7bd3829819b71170c4) | `` python3Packages.pydantic-ai-slim: 1.82.0 -> 1.84.1 ``                                               |
| [`195f6b92`](https://github.com/NixOS/nixpkgs/commit/195f6b92012fe49b7c95fdcc445416c79c1279ac) | `` python3Packages.pydantic-graph: 1.82.0 -> 1.84.1 ``                                                 |
| [`80dcff1f`](https://github.com/NixOS/nixpkgs/commit/80dcff1fd9ecf2610480440a0d5b2c8478fe42fe) | `` python3Packages.clarifai-grpc: 12.0.6 -> 12.3.1 ``                                                  |
| [`48e723f2`](https://github.com/NixOS/nixpkgs/commit/48e723f27773eca0efede747c3e34e112e1a1dd4) | `` ytdl-sub: 2026.03.19 -> 2026.04.13.post1 ``                                                         |
| [`48ddd1b4`](https://github.com/NixOS/nixpkgs/commit/48ddd1b485b3b1203b98fe12e9a82ebe09ca5e52) | `` {opencode,opencode-desktop}: 1.4.11 -> 1.14.19 ``                                                   |
| [`49b24994`](https://github.com/NixOS/nixpkgs/commit/49b249946f11b7ed1cd27a6bad3bb94964c7810d) | `` slackdump: 4.1.2 -> 4.3.0 ``                                                                        |
| [`18a45c1d`](https://github.com/NixOS/nixpkgs/commit/18a45c1d8db41ce5f987fbb9af5a4dfe114a6e5d) | `` tailwindcss_4: 4.2.2 -> 4.2.3 ``                                                                    |
| [`0ca7b4d5`](https://github.com/NixOS/nixpkgs/commit/0ca7b4d53b5392ff5ba2aeadde5c146b9c5a121e) | `` python3Packages.social-auth-app-django: 5.7.0 -> 5.8.0 ``                                           |
| [`f0cc30d2`](https://github.com/NixOS/nixpkgs/commit/f0cc30d2197d15df94c2541069e3d7af3bb43710) | `` androidStudioPackages.canary: 2025.3.4.4 -> 2026.1.1.1 ``                                           |
| [`a9a082e6`](https://github.com/NixOS/nixpkgs/commit/a9a082e61622aa9889929c0640150a512bbeaf2b) | `` sublime-merge: 2123 -> 2125 ``                                                                      |
| [`de523ce4`](https://github.com/NixOS/nixpkgs/commit/de523ce492491a2a622df1a11d14632577867da5) | `` glitchtip: 6.1.4 -> 6.1.6 ``                                                                        |
| [`dee9dea5`](https://github.com/NixOS/nixpkgs/commit/dee9dea59ae5188823f3d2aef8f22021b5a6c32a) | `` rawst: init at 0.8.1 ``                                                                             |
| [`5e4bbd09`](https://github.com/NixOS/nixpkgs/commit/5e4bbd09754479e887a991a20043e2ea4170da8d) | `` firefox-esr-140-unwrapped: 140.9.1esr -> 140.10.0esr ``                                             |
| [`65e61761`](https://github.com/NixOS/nixpkgs/commit/65e6176112ace26cdee65cb2ff9b0de1a073b872) | `` firefox-bin-unwrapped: 149.0.2 -> 150.0 ``                                                          |
| [`14bb5b0d`](https://github.com/NixOS/nixpkgs/commit/14bb5b0d09b4e120e99310dae74574dba74acb4a) | `` firefox-unwrapped: 149.0.2 -> 150.0 ``                                                              |
| [`23067e84`](https://github.com/NixOS/nixpkgs/commit/23067e84274cd3c16d9b4a5c9bb69ce5fed8fcf0) | `` irpf: 2026-1.0 -> 2026-1.1 ``                                                                       |
| [`ae6d6010`](https://github.com/NixOS/nixpkgs/commit/ae6d6010b45aa3c9957c688858c83924b2eead38) | `` irpf: Remove unnecessary internal file version ``                                                   |
| [`26c26837`](https://github.com/NixOS/nixpkgs/commit/26c2683755feee4edca58c8ecbb6ec9559840669) | `` python3Packages.cuda-bindings: 12.8.0 -> 12.9.6 ``                                                  |
| [`9d5e0adf`](https://github.com/NixOS/nixpkgs/commit/9d5e0adf5538abc92096cfcb6e12230955a651f7) | `` ankiAddons.fsrs4anki-helper: 24.06.3-unstable-2026-03-30 -> 24.06.3-unstable-2026-04-14 ``          |
| [`c04aa476`](https://github.com/NixOS/nixpkgs/commit/c04aa476bc5eba49a68c0f8ae50a07f5e8c37dee) | `` azure-cli-extensions.confcom: 1.8.0 -> 2.0.0b1 ``                                                   |
| [`c2ad7477`](https://github.com/NixOS/nixpkgs/commit/c2ad7477871ba9216be0858773e33c04af567b90) | `` lsv: init at 0.1.15 ``                                                                              |
| [`ed4ed652`](https://github.com/NixOS/nixpkgs/commit/ed4ed6523e1a8dc4ccff38fd0702f99665a91569) | `` python3Packages.fastcore: 1.12.38 -> 1.12.39 ``                                                     |
| [`c3cb745a`](https://github.com/NixOS/nixpkgs/commit/c3cb745a011fc656995d1a6d9745b3a45c77e209) | `` vscode-extensions.ms-vscode.js-debug: 1.112.0 -> 1.117.0 ``                                         |
| [`c701505f`](https://github.com/NixOS/nixpkgs/commit/c701505fcacf5029e607dc45a1c504b4466a14f7) | `` bngblaster: 0.9.33 -> 0.9.34 ``                                                                     |
| [`025afd73`](https://github.com/NixOS/nixpkgs/commit/025afd731a991e92b14092e06e8d912d943f1489) | `` actual-server: set `__darwinAllowLocalNetworking = true` ``                                         |
| [`27edb972`](https://github.com/NixOS/nixpkgs/commit/27edb972ad37776432b13cfa62a353bf2b43028b) | `` circleci-cli: 0.1.34950 -> 0.1.35213 ``                                                             |
| [`1351469d`](https://github.com/NixOS/nixpkgs/commit/1351469d53b8dee0047254f62cb89eda189258d7) | `` seconlay: 0-unstable-2026-04-10 -> 0-unstable-2026-04-13 ``                                         |
| [`0c1e7a3d`](https://github.com/NixOS/nixpkgs/commit/0c1e7a3da2fcd57c38ad7193d7a114cea29a2e18) | `` renode-unstable: 1.16.1-unstable-2026-04-12 -> 1.16.1-unstable-2026-04-20 ``                        |
| [`6aae5e74`](https://github.com/NixOS/nixpkgs/commit/6aae5e74f82931c3e7392bcf7b1ae482954bdb2f) | `` ueransim: 3.2.6 -> 3.2.8 ``                                                                         |
| [`b8084f36`](https://github.com/NixOS/nixpkgs/commit/b8084f36a6d679ec626817b12a152ff051a7ad89) | `` decktape: 3.16.0 -> 3.16.1 ``                                                                       |
| [`5b7c8c3c`](https://github.com/NixOS/nixpkgs/commit/5b7c8c3c343fcc9f4a353b71244467541dce41a4) | `` vscode-extensions.shd101wyy.markdown-preview-enhanced: 0.8.22 -> 0.8.24 ``                          |
| [`1bf9f867`](https://github.com/NixOS/nixpkgs/commit/1bf9f8675a74cc1836421849c9b1818aa2c70469) | `` wesnoth-devel: 1.19.22 -> 1.19.23 ``                                                                |
| [`10591d00`](https://github.com/NixOS/nixpkgs/commit/10591d00f6b62b635317eea55a4395eaf906316b) | `` pkgsite: 0-unstable-2026-04-10 -> 0-unstable-2026-04-17 ``                                          |
| [`8dad9ee5`](https://github.com/NixOS/nixpkgs/commit/8dad9ee5242b96559efb8e62712e4cf187817da1) | `` miranda: use gcc14Stdenv to fix build ``                                                            |
| [`4c907dbb`](https://github.com/NixOS/nixpkgs/commit/4c907dbb68ff92ec570bedfc53ad58d67862e48b) | `` Revert "nixos-test-driver: use info/error/debug log feature more" ``                                |
| [`2454755d`](https://github.com/NixOS/nixpkgs/commit/2454755d51ad5a463755265284da4baf4a5087be) | `` ci/parse: Test latest Lix ``                                                                        |
| [`1edb73a7`](https://github.com/NixOS/nixpkgs/commit/1edb73a7fe0f0a659c07264e1baec940237977cc) | `` ci/parse: Fail on warning ``                                                                        |
| [`84159b68`](https://github.com/NixOS/nixpkgs/commit/84159b6865845bae7fcd4ac50456de51468589f2) | `` geesefs: 0.43.5 -> 0.43.6 ``                                                                        |
| [`98ac7ea4`](https://github.com/NixOS/nixpkgs/commit/98ac7ea42ee1223f1bf0b19ff51209b2db3d7faf) | `` nixos/pid-fan-controller: RFC42 treatment ``                                                        |
| [`0f420e96`](https://github.com/NixOS/nixpkgs/commit/0f420e96c4d2f7e465f816efeb98802f111d9d6d) | `` gcc, libgcc: fix cross-compilation for SH4 ``                                                       |
| [`0fcb031c`](https://github.com/NixOS/nixpkgs/commit/0fcb031c250ffecf6abcc69b78ac7d1cc805de39) | `` lib/systems: add SH4 (SuperH) cross-compilation target ``                                           |
| [`752b27da`](https://github.com/NixOS/nixpkgs/commit/752b27da04c5a286992f7e3279675275519ccd28) | `` cura-appimage: 5.12.0 -> 5.12.1 ``                                                                  |
| [`788256d5`](https://github.com/NixOS/nixpkgs/commit/788256d591bb2d04efe5dd78dd62edc1a1f56eb4) | `` goeland: 0.23.0 -> 0.24.0 ``                                                                        |
| [`fd65fa0e`](https://github.com/NixOS/nixpkgs/commit/fd65fa0e62d3098ea18e836a077351995d5f75fe) | `` codex: build only codex and disable LTO to halve build time ``                                      |
| [`0f125107`](https://github.com/NixOS/nixpkgs/commit/0f12510790b1d45db88937f48b4c7c8f214a2119) | `` nixos/pid-fan-controller: systemd units are now vendored ``                                         |
| [`06e0e293`](https://github.com/NixOS/nixpkgs/commit/06e0e2936229d9def5e6326ff9e0a6db94345371) | `` libargs: 6.4.8 -> 6.4.9 ``                                                                          |
| [`534db738`](https://github.com/NixOS/nixpkgs/commit/534db73876fb81b0a8a5a0d8e94073022b1336bc) | `` python3Packages.env-canada: 0.14.1 -> 0.15.0 ``                                                     |
| [`c8e3eb09`](https://github.com/NixOS/nixpkgs/commit/c8e3eb093ee34e47e269fec845c930f6d94d9d88) | `` pvz-portable-unwrapped: 0.1.20 -> 0.1.21 ``                                                         |
| [`16c06bfc`](https://github.com/NixOS/nixpkgs/commit/16c06bfcb66ff64a81bd7beae17f6ba121a4ab00) | `` protonmail-bridge: 3.23.1 -> 3.24.1 ``                                                              |
| [`4c66d6c5`](https://github.com/NixOS/nixpkgs/commit/4c66d6c50b198f2e0c1723a43c4ad3152b99075a) | `` protoc-gen-connect-go: 1.19.1 -> 1.19.2 ``                                                          |
| [`ace0d465`](https://github.com/NixOS/nixpkgs/commit/ace0d4659fc2847ea1ffee0675f8522c9df7d5b9) | `` sendme: 0.32.0 -> 0.33.0 ``                                                                         |
| [`844db9c5`](https://github.com/NixOS/nixpkgs/commit/844db9c50e77c1d3e62c4ef52aab36a6877dc8e3) | `` railway-wallet: 5.24.18 -> 5.24.21 ``                                                               |
| [`a9dd7677`](https://github.com/NixOS/nixpkgs/commit/a9dd7677b63b0913b592756146f656fbfb158df2) | `` libgda5: fix C23 md5c.c build ``                                                                    |
| [`f289a13f`](https://github.com/NixOS/nixpkgs/commit/f289a13fd78df51c0e184afd1ae4303b82c4d4d9) | `` dotenvx: 1.61.0 -> 1.61.1 ``                                                                        |
| [`d344b1fd`](https://github.com/NixOS/nixpkgs/commit/d344b1fd7e51eba220cf967af23b1fa22ebae3a6) | `` kdePackages.dolphin: set meta.mainProgram to dolphin ``                                             |
| [`42a47c25`](https://github.com/NixOS/nixpkgs/commit/42a47c25ff4a8213594857d06ebce6f5420dff7c) | `` vapoursynth-nnedi3: drop ``                                                                         |
| [`97b5957e`](https://github.com/NixOS/nixpkgs/commit/97b5957e8dfb85ace59413510d5ce30956bf3893) | `` just: 1.49.0 -> 1.50.0 ``                                                                           |
| [`34d2056f`](https://github.com/NixOS/nixpkgs/commit/34d2056ff55d49ced8eab21d0d2ba1f2d00bc57d) | `` buf: 1.67.0 -> 1.68.2 ``                                                                            |
| [`c32ad896`](https://github.com/NixOS/nixpkgs/commit/c32ad896dfe86f32572d50645aa4ec73214e5faf) | `` fresh-editor: 0.2.23 -> 0.2.25 ``                                                                   |
| [`9c3ef5e1`](https://github.com/NixOS/nixpkgs/commit/9c3ef5e1289592bdbcc581c54378f86da531e30a) | `` flyctl: 0.4.33 -> 0.4.36 ``                                                                         |
| [`bf742d7e`](https://github.com/NixOS/nixpkgs/commit/bf742d7ec94fb7fb51410cdad54e8e9ac4b780c7) | `` cantus: 0.6.4 -> 0.6.5 ``                                                                           |

*... and 1152 more commits (truncated)*