### PR TITLE
chore(flake/nixpkgs): `1c3fe55a` -> `15f4ee45`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -81,11 +81,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777268161,
-        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
+        "lastModified": 1777578337,
+        "narHash": "sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM+Z4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
+        "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`86c8158c`](https://github.com/NixOS/nixpkgs/commit/86c8158c29568c54da696ec2731c6aa761ecdf0b) | `` prometheus-mongodb-exporter: 0.50.0 -> 0.51.0 ``                                    |
| [`6bee4b7c`](https://github.com/NixOS/nixpkgs/commit/6bee4b7c8ed63cff2d0cb40cfc49e9d6f1d5d846) | `` cdncheck: 1.2.32 -> 1.2.33 ``                                                       |
| [`ee19e4a0`](https://github.com/NixOS/nixpkgs/commit/ee19e4a048ffa7ba7fece2008629eb270a5ff663) | `` tf: 2.11.2 -> 2.12.0 ``                                                             |
| [`4195b238`](https://github.com/NixOS/nixpkgs/commit/4195b23876bec74be49a1df171a4e35dd119534c) | `` volanta: 1.17.2 -> 1.17.5 ``                                                        |
| [`b120931e`](https://github.com/NixOS/nixpkgs/commit/b120931e5797238f36faa9c78c6b15fc540569c2) | `` gh: use --set-default for GH_TELEMETRY env var ``                                   |
| [`6af68b9b`](https://github.com/NixOS/nixpkgs/commit/6af68b9b6e74eb9f4abf8acee1c6958ea705f937) | `` csvs-to-sqlite: 1.3.0 -> 1.3.1 ``                                                   |
| [`5d1d92d0`](https://github.com/NixOS/nixpkgs/commit/5d1d92d08ca25ea8fa094fce097e30ea570bbfaa) | `` python3Packages.streamlit-folium: 0.27.1 -> 0.27.2 ``                               |
| [`df6d7e2a`](https://github.com/NixOS/nixpkgs/commit/df6d7e2a9c6635b3d177bc333e92e13b4e7ff0be) | `` cerberus: re-enable install-check tests ``                                          |
| [`2e88a548`](https://github.com/NixOS/nixpkgs/commit/2e88a548ea069cf05e5fc2683f578db94ab4fb8e) | `` cnspec: 13.6.0 -> 13.7.0 ``                                                         |
| [`5437e4e3`](https://github.com/NixOS/nixpkgs/commit/5437e4e34975239bb726b2720777eeb24597e8b7) | `` gh: 2.91.0 -> 2.92.0 ``                                                             |
| [`36c9adab`](https://github.com/NixOS/nixpkgs/commit/36c9adab7878184dc2d5517ddb3e576c2cf35539) | `` auth0-cli: 1.29.0 -> 1.30.0 ``                                                      |
| [`ad39f6cb`](https://github.com/NixOS/nixpkgs/commit/ad39f6cb9ff1b03b98464770da02c39261e8ab18) | `` cudaPackages.nvbandwidth: init at 0.9 ``                                            |
| [`58107ef3`](https://github.com/NixOS/nixpkgs/commit/58107ef300bfa77250d27097df9c75c7aebac726) | `` jsonschema-cli: 0.46.2 -> 0.46.3 ``                                                 |
| [`d65a4783`](https://github.com/NixOS/nixpkgs/commit/d65a4783f5ca4edf6de19e16ce4e6d96e5ce887b) | `` prometheus-pve-exporter: 3.8.2 -> 3.8.3 ``                                          |
| [`cb0a0e4d`](https://github.com/NixOS/nixpkgs/commit/cb0a0e4d6fe1cb7f7a96861b79e82405e575ba08) | `` grafanaPlugins.grafana-clickhouse-datasource: 4.15.0 -> 4.16.0 ``                   |
| [`9da1c3a4`](https://github.com/NixOS/nixpkgs/commit/9da1c3a415da128c74e73c48c7ab0d2142e2f401) | `` thunderbird-mcp: 0.4.0 -> 0.5.0 ``                                                  |
| [`eca5db0e`](https://github.com/NixOS/nixpkgs/commit/eca5db0eef1ab67dbb6b0b2e8f7d5061dfc490b6) | `` jreleaser-cli: 1.23.0 -> 1.24.0 ``                                                  |
| [`56f11a0d`](https://github.com/NixOS/nixpkgs/commit/56f11a0d7328ec41dd1899aea6f4cbdbeadcc835) | `` obliteratus: init at 0.1.2-unstable-2026-03-05 ``                                   |
| [`3a740d66`](https://github.com/NixOS/nixpkgs/commit/3a740d661794fdd388f49c40f0234beda6421711) | `` SDL_image: 1.2.12-unstable-2026-04-03 -> 1.2.12-unstable-2026-04-29 ``              |
| [`253c274d`](https://github.com/NixOS/nixpkgs/commit/253c274dbff2c92a5fc1d5713c10010e64c67d53) | `` terraform-providers.checkly_checkly: 1.21.1 -> 1.22.0 ``                            |
| [`8728240d`](https://github.com/NixOS/nixpkgs/commit/8728240d47547ac9085674dc0a7a680d9c49d882) | `` python3Packages.hcloud: 2.17.1 -> 2.19.0 ``                                         |
| [`fb236f8a`](https://github.com/NixOS/nixpkgs/commit/fb236f8a82a2919116906cc0c63eec512ee92087) | `` python3Packages.gerbonara: migrate to finalAttrs ``                                 |
| [`90f01c9c`](https://github.com/NixOS/nixpkgs/commit/90f01c9cfda4df42bcaef4bb32d928137cdc7255) | `` python3Packages.gerbonara: 1.6.2 -> 1.6.3 ``                                        |
| [`b35a6dc4`](https://github.com/NixOS/nixpkgs/commit/b35a6dc4c89a64abd2d6ea75283061793d0e0963) | `` files-cli: 2.15.274 -> 2.15.282 ``                                                  |
| [`554d31a8`](https://github.com/NixOS/nixpkgs/commit/554d31a873b8822ff8f5d0d6499725cf242cb340) | `` Revert "k3s: fix build reproducibility" ``                                          |
| [`03144b4b`](https://github.com/NixOS/nixpkgs/commit/03144b4b5c2e07555462dffa951c2845470d578a) | `` kiro-cli: 2.0.1 -> 2.2.0 ``                                                         |
| [`ee583543`](https://github.com/NixOS/nixpkgs/commit/ee5835436bf46febfd7b215404d7d0f36276e62b) | `` python3Packages.msticpy: migrate to finalAttrs ``                                   |
| [`359225de`](https://github.com/NixOS/nixpkgs/commit/359225def4473f704d22bf2c24f480fc181ee5b2) | `` signal-desktop: install policy templates on linux ``                                |
| [`7b162bff`](https://github.com/NixOS/nixpkgs/commit/7b162bffb09de03733e6687d6fd1bf9954100832) | `` lazyhetzner: 1.2.0 -> 1.3.0 ``                                                      |
| [`7f009522`](https://github.com/NixOS/nixpkgs/commit/7f009522e2ab6316c947d78c41bb586c2dbffaa1) | `` mistral-vibe: 2.9.2 -> 2.9.3 ``                                                     |
| [`0f7bf7bc`](https://github.com/NixOS/nixpkgs/commit/0f7bf7bc18485b8dbd26d5802231f39e8582d7ee) | `` kanidm_1_9: 1.9.2 -> 1.9.3 ``                                                       |
| [`a28c101b`](https://github.com/NixOS/nixpkgs/commit/a28c101b834daa7bd8eb8ff2315054431320faad) | `` kanidm_1_8: mark unsupported ``                                                     |
| [`150b07e4`](https://github.com/NixOS/nixpkgs/commit/150b07e405ac36f56980bd4721a911cefc599924) | `` kanidm_1_7: drop as eol ``                                                          |
| [`0d5f4ea1`](https://github.com/NixOS/nixpkgs/commit/0d5f4ea1d5e3f641cab28e304d34d86d6b9bb419) | `` porxie: 0.1.0 -> 0.1.2 ``                                                           |
| [`54b36a7a`](https://github.com/NixOS/nixpkgs/commit/54b36a7aa7e69d7936c5616c16ea61999e0c3a98) | `` proton-pass-cli: 2.0.0 -> 2.0.2 ``                                                  |
| [`5e163765`](https://github.com/NixOS/nixpkgs/commit/5e163765ee7459a2bac688e48cfdda66f06681e5) | `` routedns: 0.1.155 -> 0.1.159 ``                                                     |
| [`ec7f8fa4`](https://github.com/NixOS/nixpkgs/commit/ec7f8fa48004f7f425fc79c0ec823d16938bd261) | `` gh: opt out of telemetry collection by default ``                                   |
| [`d673520c`](https://github.com/NixOS/nixpkgs/commit/d673520c20d1be1968641f2cc5a4a4ec79901a48) | `` virter: 0.30.0 -> 1.0.0 ``                                                          |
| [`7f5b1047`](https://github.com/NixOS/nixpkgs/commit/7f5b104771faf90ebbf2aa337e9fe9adc35ebd09) | `` qjackctl: 1.0.5 -> 1.0.6 ``                                                         |
| [`a21f98fa`](https://github.com/NixOS/nixpkgs/commit/a21f98fabcd4ca6d672631732327643e2e0d6812) | `` nixVersions.nixComponents_2_34.nix-util-tests: disable failing test ``              |
| [`14881e4b`](https://github.com/NixOS/nixpkgs/commit/14881e4b966c455499064a6401fcc6ab36923877) | `` python3Packages.pysigma: 1.3.2 -> 1.3.3 ``                                          |
| [`3d23c056`](https://github.com/NixOS/nixpkgs/commit/3d23c0560a2f960755e738f41995c131ea78bfcc) | `` luaPackages.vicious: update changelog url ``                                        |
| [`b91f3ba0`](https://github.com/NixOS/nixpkgs/commit/b91f3ba0c23291a81297f78e708a2c07f180588b) | `` anders: remove myself from maintainers ``                                           |
| [`f230eb09`](https://github.com/NixOS/nixpkgs/commit/f230eb09078ed126579ff94c303acecaf21aad2a) | `` python3Packages.msticpy: 2.17.2 -> 3.0.0 ``                                         |
| [`2d3f7555`](https://github.com/NixOS/nixpkgs/commit/2d3f7555fc253a62116a5c13e254a4b400584a3d) | `` models-dev: 0-unstable-2026-04-20 -> 0-unstable-2026-04-29 ``                       |
| [`b7de90d9`](https://github.com/NixOS/nixpkgs/commit/b7de90d9312f4d203e3c7a99ca01829a6d4b9a2b) | `` linux_5_10: 5.10.253 -> 5.10.254 ``                                                 |
| [`33264a49`](https://github.com/NixOS/nixpkgs/commit/33264a49e877f5f8454d797f3bf63f982dbfee89) | `` linux_5_15: 5.15.203 -> 5.15.204 ``                                                 |
| [`5a838789`](https://github.com/NixOS/nixpkgs/commit/5a838789192297b23e6d2d2b653f5a2a6def504d) | `` linux_6_1: 6.1.169 -> 6.1.170 ``                                                    |
| [`21980cc1`](https://github.com/NixOS/nixpkgs/commit/21980cc1a04edb6596e1aed94af692b5aafc8456) | `` linux_6_6: 6.6.136 -> 6.6.137 ``                                                    |
| [`cf998ff8`](https://github.com/NixOS/nixpkgs/commit/cf998ff809f09ef90037a9083bf904c01dbfafcf) | `` linux_6_12: 6.12.84 -> 6.12.85 ``                                                   |
| [`5010ed73`](https://github.com/NixOS/nixpkgs/commit/5010ed73b8d49e427a8371a9dca3c96575c14579) | `` linux_6_18: 6.18.25 -> 6.18.26 ``                                                   |
| [`bb297ea3`](https://github.com/NixOS/nixpkgs/commit/bb297ea30b204e53a6936d0e741c9f8eff8865e5) | `` linux_7_0: 7.0.2 -> 7.0.3 ``                                                        |
| [`0f5e988b`](https://github.com/NixOS/nixpkgs/commit/0f5e988b2e728f6515f2c2fea5778ec25fa6f592) | `` python3Packages.waterfurnace: 1.7.1 -> 1.8.0 ``                                     |
| [`7d0201df`](https://github.com/NixOS/nixpkgs/commit/7d0201dfa6c251d8e10adeb36ed750c5ec82cf6d) | `` kodi: use passthru packages in withPackages ``                                      |
| [`c0df0d08`](https://github.com/NixOS/nixpkgs/commit/c0df0d088ab33122b402ea31cb5f7e1df7536036) | `` llama-cpp: 8864 -> 8983 ``                                                          |
| [`4ccae7f7`](https://github.com/NixOS/nixpkgs/commit/4ccae7f7376d21d4bc9b88d6ebb7f6304421c05f) | `` wireshark: fix meta.changelog ``                                                    |
| [`9b84e0b1`](https://github.com/NixOS/nixpkgs/commit/9b84e0b1f872e47f553b2ee280409cb2569796bd) | `` cherry-studio: 1.9.2 -> 1.9.3 ``                                                    |
| [`2af5c3f5`](https://github.com/NixOS/nixpkgs/commit/2af5c3f5cd58b4010087fe0ba9ad2f1bc09f8c89) | `` llmfit: Update description ``                                                       |
| [`03e4d461`](https://github.com/NixOS/nixpkgs/commit/03e4d46144215391fcb915a3637e5f03206b6f6d) | `` ocamlPackages.elpi: 3.6.2 -> 3.7.1 ``                                               |
| [`f2f33415`](https://github.com/NixOS/nixpkgs/commit/f2f334153d02477bc4b0d5511b795fce7eb74fbd) | `` terraform-providers.scaleway_scaleway: 2.73.0 -> 2.74.0 ``                          |
| [`508cea6e`](https://github.com/NixOS/nixpkgs/commit/508cea6eddfd2929b62583ce948cea3080acd642) | `` ghdump: init at 0.1.1 ``                                                            |
| [`0b1947ca`](https://github.com/NixOS/nixpkgs/commit/0b1947cab9cbca2542687931c1ab5834fa3def3a) | `` vscode-extensions.tsandall.opa: 0.22.1 -> 0.23.0 ``                                 |
| [`30838bf8`](https://github.com/NixOS/nixpkgs/commit/30838bf80b4ea1e26185b3b77598e7016d7b99bb) | `` dokieli: 0-unstable-2026-04-20 -> 0-unstable-2026-04-27 ``                          |
| [`575a009d`](https://github.com/NixOS/nixpkgs/commit/575a009d5440c2a8a4fe5a8093d3e7191144f283) | `` python3Packages.iaqualink: 0.6.0 -> 0.7.0 ``                                        |
| [`faf8b611`](https://github.com/NixOS/nixpkgs/commit/faf8b6119f99aad757f0fe66afd44ff4fe53ef8f) | `` python3Packages.httpx-retries: init at 0.5.0 ``                                     |
| [`765ed8d4`](https://github.com/NixOS/nixpkgs/commit/765ed8d48d98fcc10b80443c146acb4a179bf5d6) | `` dns-collector: 2.2.1 -> 2.2.2 ``                                                    |
| [`da0f251f`](https://github.com/NixOS/nixpkgs/commit/da0f251f10ac1a8c9e8338733a36dc62add51d75) | `` buildbox: 1.4.4 -> 1.4.5 ``                                                         |
| [`77ca04b0`](https://github.com/NixOS/nixpkgs/commit/77ca04b0b34daa28ffc719cd8b92fefd5568a451) | `` python3Packages.deebot-client: 18.1.0 -> 18.2.0 ``                                  |
| [`fa192db3`](https://github.com/NixOS/nixpkgs/commit/fa192db365bb0083a8e973bf359e7a33274ba0d7) | `` python3Packages.banks: 2.4.1 -> 2.4.2 ``                                            |
| [`01570803`](https://github.com/NixOS/nixpkgs/commit/0157080348b93fc78f688bd2cd1924bb6d887746) | `` svix-server: 1.90.0 -> 1.92.2 ``                                                    |
| [`a36355b3`](https://github.com/NixOS/nixpkgs/commit/a36355b3f46977fe117742f07e230683f8179d65) | `` docker-color-output: fix changelog URL ``                                           |
| [`37e15c57`](https://github.com/NixOS/nixpkgs/commit/37e15c577a736e5b474577402e6505b61c0c2b06) | `` exploitdb: 2026-04-23 -> 2026-04-30 ``                                              |
| [`4aedf12a`](https://github.com/NixOS/nixpkgs/commit/4aedf12a21b49a2102e87c3391277a3a11430ebd) | `` ocamlPackages.httpcats: fix darwin build ``                                         |
| [`189f69f5`](https://github.com/NixOS/nixpkgs/commit/189f69f51c49df32625020d96d170fd7842aaadf) | `` gdu: 5.35.0 -> 5.36.1 ``                                                            |
| [`162d2611`](https://github.com/NixOS/nixpkgs/commit/162d26119c6c6c46f61472bfc4ffadd0bbac67bf) | `` goshs: 2.0.5 -> 2.0.6 ``                                                            |
| [`50c9db7c`](https://github.com/NixOS/nixpkgs/commit/50c9db7cb0febcda3acedc6166c2ad5c767a04d1) | `` python3Packages.boto3-stubs: 1.42.97 -> 1.43.0 ``                                   |
| [`0c806abe`](https://github.com/NixOS/nixpkgs/commit/0c806abe0f9a273ce618cc89863fc7640a341e48) | `` python3Packages.mypy-boto3-xray: 1.42.3 -> 1.43.0 ``                                |
| [`1039a248`](https://github.com/NixOS/nixpkgs/commit/1039a248811f191e6375131fc4268d0c639e6dbf) | `` python3Packages.mypy-boto3-workspaces-web: 1.42.51 -> 1.43.0 ``                     |
| [`8fcf1d43`](https://github.com/NixOS/nixpkgs/commit/8fcf1d4329cb2487eebb42fead0d67e23ef7bff7) | `` python3Packages.mypy-boto3-workspaces: 1.42.97 -> 1.43.0 ``                         |
| [`4e69d763`](https://github.com/NixOS/nixpkgs/commit/4e69d763d25d9a2df6b3723eb944a7945bcaafc3) | `` python3Packages.mypy-boto3-workmailmessageflow: 1.42.3 -> 1.43.0 ``                 |
| [`6810442e`](https://github.com/NixOS/nixpkgs/commit/6810442ef5c788b26b25499039292dea4b276783) | `` python3Packages.mypy-boto3-workmail: 1.42.3 -> 1.43.0 ``                            |
| [`507cc1e3`](https://github.com/NixOS/nixpkgs/commit/507cc1e32833dde02bb02b9dafa739b82f3e0ee9) | `` python3Packages.mypy-boto3-workdocs: 1.42.3 -> 1.43.0 ``                            |
| [`f12142b5`](https://github.com/NixOS/nixpkgs/commit/f12142b558a681e762b1f2a7ad18a982dafad906) | `` python3Packages.mypy-boto3-wisdom: 1.42.3 -> 1.43.0 ``                              |
| [`3cc95be3`](https://github.com/NixOS/nixpkgs/commit/3cc95be3a6246232da20061c8b057a091220c2d9) | `` python3Packages.mypy-boto3-wellarchitected: 1.42.3 -> 1.43.0 ``                     |
| [`2e4628a8`](https://github.com/NixOS/nixpkgs/commit/2e4628a8ab471f0b86797f8f54e096fc502e8c69) | `` python3Packages.mypy-boto3-wafv2: 1.42.57 -> 1.43.0 ``                              |
| [`e9395978`](https://github.com/NixOS/nixpkgs/commit/e939597895666646724e0f222c875f82eef4e606) | `` python3Packages.mypy-boto3-waf-regional: 1.42.3 -> 1.43.0 ``                        |
| [`ea3ba0ad`](https://github.com/NixOS/nixpkgs/commit/ea3ba0adfa42cace53703a36dfd203e261bacf0c) | `` python3Packages.mypy-boto3-waf: 1.42.3 -> 1.43.0 ``                                 |
| [`096d475c`](https://github.com/NixOS/nixpkgs/commit/096d475ce7069dfe01e6b9dbebe6444cffeb3022) | `` python3Packages.mypy-boto3-vpc-lattice: 1.42.3 -> 1.43.0 ``                         |
| [`c538fa1d`](https://github.com/NixOS/nixpkgs/commit/c538fa1d94852393ea5cbab1a753d3bc6acb44e8) | `` python3Packages.mypy-boto3-voice-id: 1.42.3 -> 1.43.0 ``                            |
| [`372b8a7d`](https://github.com/NixOS/nixpkgs/commit/372b8a7d70882e53cf48cc893d044ef3eef982e2) | `` python3Packages.mypy-boto3-verifiedpermissions: 1.42.73 -> 1.43.0 ``                |
| [`3b94ced5`](https://github.com/NixOS/nixpkgs/commit/3b94ced5cd4add25762e66c5fcead43962fa50cf) | `` python3Packages.mypy-boto3-translate: 1.42.3 -> 1.43.0 ``                           |
| [`3c3f3706`](https://github.com/NixOS/nixpkgs/commit/3c3f37069132bcebf78166415438fad15158a674) | `` python3Packages.mypy-boto3-transfer: 1.42.96 -> 1.43.0 ``                           |
| [`4089c6f2`](https://github.com/NixOS/nixpkgs/commit/4089c6f256b46a596b17e2d92d0aa38bfd22b20c) | `` python3Packages.mypy-boto3-transcribe: 1.42.25 -> 1.43.0 ``                         |
| [`3d3528ff`](https://github.com/NixOS/nixpkgs/commit/3d3528fff04d5a66aa4add5c063125f2bf8c4115) | `` python3Packages.mypy-boto3-tnb: 1.42.3 -> 1.43.0 ``                                 |
| [`eadb145b`](https://github.com/NixOS/nixpkgs/commit/eadb145b0e53ce2624b8cf31c6586dbafb6edb15) | `` python3Packages.mypy-boto3-timestream-write: 1.42.3 -> 1.43.0 ``                    |
| [`e04c1520`](https://github.com/NixOS/nixpkgs/commit/e04c152025cb522fba0e39622186407415b5c8d9) | `` python3Packages.mypy-boto3-timestream-query: 1.42.3 -> 1.43.0 ``                    |
| [`9d9b6600`](https://github.com/NixOS/nixpkgs/commit/9d9b6600249562deca30fc1d5e20aef6c16993a6) | `` python3Packages.mypy-boto3-textract: 1.42.3 -> 1.43.0 ``                            |
| [`69d97377`](https://github.com/NixOS/nixpkgs/commit/69d97377d743549ed4eb53eb3ba218884cd39bcd) | `` python3Packages.mypy-boto3-synthetics: 1.42.3 -> 1.43.0 ``                          |
| [`4cd58378`](https://github.com/NixOS/nixpkgs/commit/4cd583786c2a24582190bf547115f25f1193e4b5) | `` python3Packages.mypy-boto3-swf: 1.42.3 -> 1.43.0 ``                                 |
| [`a9a166a7`](https://github.com/NixOS/nixpkgs/commit/a9a166a7d527afaf478c055bc68c6b226309e133) | `` python3Packages.mypy-boto3-support-app: 1.42.3 -> 1.43.0 ``                         |
| [`bd4531f8`](https://github.com/NixOS/nixpkgs/commit/bd4531f83734a2253df4ae6c10098fa71a33cd73) | `` python3Packages.mypy-boto3-support: 1.42.3 -> 1.43.0 ``                             |
| [`57fc155d`](https://github.com/NixOS/nixpkgs/commit/57fc155da840325ca538311f98c6013e9cc4c31d) | `` python3Packages.mypy-boto3-sts: 1.42.91 -> 1.43.0 ``                                |
| [`5db4fc72`](https://github.com/NixOS/nixpkgs/commit/5db4fc72c6a0b9012c143a449900c835d1cb8694) | `` python3Packages.mypy-boto3-storagegateway: 1.42.3 -> 1.43.0 ``                      |
| [`2f700427`](https://github.com/NixOS/nixpkgs/commit/2f700427a78806e72c76d5862f7c1b027a1b8c1b) | `` python3Packages.mypy-boto3-stepfunctions: 1.42.3 -> 1.43.0 ``                       |
| [`3c3bc083`](https://github.com/NixOS/nixpkgs/commit/3c3bc0834c37c40524027420dae0bf1e08070786) | `` python3Packages.mypy-boto3-sso-oidc: 1.42.67 -> 1.43.0 ``                           |
| [`52cd298b`](https://github.com/NixOS/nixpkgs/commit/52cd298b4c01f34e55ba582b7cd3f9ddbc11d232) | `` python3Packages.mypy-boto3-sso-admin: 1.42.41 -> 1.43.0 ``                          |
| [`5a318f6f`](https://github.com/NixOS/nixpkgs/commit/5a318f6f26c726350b3d29fc8d18489cf987b9a6) | `` python3Packages.mypy-boto3-sso: 1.42.3 -> 1.43.0 ``                                 |
| [`4ada915a`](https://github.com/NixOS/nixpkgs/commit/4ada915a50ee0eb2d89339e767f158a21d5522bf) | `` python3Packages.mypy-boto3-ssm-sap: 1.42.13 -> 1.43.0 ``                            |
| [`ddf3b806`](https://github.com/NixOS/nixpkgs/commit/ddf3b8063c11132add522e165f065a81722a263d) | `` python3Packages.mypy-boto3-ssm-incidents: 1.42.3 -> 1.43.0 ``                       |
| [`8107ecff`](https://github.com/NixOS/nixpkgs/commit/8107ecffe4714a13a5c4534529169b9391ba528f) | `` python3Packages.mypy-boto3-ssm-contacts: 1.42.3 -> 1.43.0 ``                        |
| [`07d990b0`](https://github.com/NixOS/nixpkgs/commit/07d990b0f679ebefbeaa192bcf97117b1eaa4a67) | `` python3Packages.mypy-boto3-ssm: 1.42.54 -> 1.43.0 ``                                |
| [`f862fe08`](https://github.com/NixOS/nixpkgs/commit/f862fe0846dedd3a0c8ad3efb795d717f4984bc4) | `` python3Packages.mypy-boto3-sqs: 1.42.3 -> 1.43.0 ``                                 |
| [`7f076d86`](https://github.com/NixOS/nixpkgs/commit/7f076d869f921645cb1e90dc4d0e33e462013a54) | `` python3Packages.mypy-boto3-sns: 1.42.3 -> 1.43.0 ``                                 |
| [`e7cefdf2`](https://github.com/NixOS/nixpkgs/commit/e7cefdf22394b1b7e05f147f850b50980e04f797) | `` python3Packages.mypy-boto3-snowball: 1.42.93 -> 1.43.0 ``                           |
| [`c988ec3c`](https://github.com/NixOS/nixpkgs/commit/c988ec3c8804de09dae7968a81f776bdedf91043) | `` python3Packages.mypy-boto3-snow-device-management: 1.42.3 -> 1.43.0 ``              |
| [`3d6e14e7`](https://github.com/NixOS/nixpkgs/commit/3d6e14e71bfd832bb4aafb6099502abd21ece600) | `` python3Packages.mypy-boto3-simspaceweaver: 1.42.3 -> 1.43.0 ``                      |
| [`b8041f7b`](https://github.com/NixOS/nixpkgs/commit/b8041f7bc1593ed84234fc668a7b07ed4b012e4d) | `` python3Packages.mypy-boto3-signer: 1.42.7 -> 1.43.0 ``                              |
| [`4e4d16b3`](https://github.com/NixOS/nixpkgs/commit/4e4d16b31e7a566ad657e5ff080dcd66244196a1) | `` python3Packages.mypy-boto3-shield: 1.42.3 -> 1.43.0 ``                              |
| [`02ec1a17`](https://github.com/NixOS/nixpkgs/commit/02ec1a17c5a8c3262a789ce4ff8c9ba0a48741db) | `` python3Packages.mypy-boto3-sesv2: 1.42.63 -> 1.43.0 ``                              |
| [`7cfb1f5d`](https://github.com/NixOS/nixpkgs/commit/7cfb1f5d5efdcecf118993906eb26307f27b48f3) | `` python3Packages.mypy-boto3-ses: 1.42.3 -> 1.43.0 ``                                 |
| [`eed7d8e1`](https://github.com/NixOS/nixpkgs/commit/eed7d8e17a9d138fad9006aa8038cf7c96739073) | `` python3Packages.mypy-boto3-servicediscovery: 1.42.3 -> 1.43.0 ``                    |
| [`0e6ff9da`](https://github.com/NixOS/nixpkgs/commit/0e6ff9da5f219baa240d19ff9868d6b9ad590009) | `` python3Packages.mypy-boto3-servicecatalog-appregistry: 1.42.3 -> 1.43.0 ``          |
| [`dbcfad6c`](https://github.com/NixOS/nixpkgs/commit/dbcfad6cf1cb5685b624297933803dc76ff4f804) | `` python3Packages.mypy-boto3-servicecatalog: 1.42.3 -> 1.43.0 ``                      |
| [`7303e20a`](https://github.com/NixOS/nixpkgs/commit/7303e20acb29dfa96e3b876e2c02a59bd0e86a6e) | `` python3Packages.mypy-boto3-service-quotas: 1.42.10 -> 1.43.0 ``                     |
| [`167e9c56`](https://github.com/NixOS/nixpkgs/commit/167e9c56257d2be0d04c44f625d6bda6f907e407) | `` python3Packages.mypy-boto3-serverlessrepo: 1.42.3 -> 1.43.0 ``                      |
| [`9541221e`](https://github.com/NixOS/nixpkgs/commit/9541221e2c55e609d3085bec7ae8c4af55bfcee3) | `` python3Packages.mypy-boto3-securitylake: 1.42.3 -> 1.43.0 ``                        |
| [`13c4eef2`](https://github.com/NixOS/nixpkgs/commit/13c4eef28bb72ba8489ddf1e3c3b9c23f5e60889) | `` python3Packages.mypy-boto3-securityhub: 1.42.89 -> 1.43.0 ``                        |
| [`b16fb8db`](https://github.com/NixOS/nixpkgs/commit/b16fb8db350d32de63be9dfd0ea9001a1d024396) | `` python3Packages.mypy-boto3-secretsmanager: 1.42.8 -> 1.43.0 ``                      |
| [`1d7380fa`](https://github.com/NixOS/nixpkgs/commit/1d7380fa54c33376126c21d66eec36f50cfe4948) | `` python3Packages.mypy-boto3-sdb: 1.42.3 -> 1.43.0 ``                                 |
| [`7c8f591f`](https://github.com/NixOS/nixpkgs/commit/7c8f591f7f477b91057f714dddddf264b2b9e3ca) | `` python3Packages.mypy-boto3-schemas: 1.42.3 -> 1.43.0 ``                             |
| [`5cd0da7e`](https://github.com/NixOS/nixpkgs/commit/5cd0da7ee466fc76e4da716b58f7cfba1125fa22) | `` python3Packages.mypy-boto3-scheduler: 1.42.3 -> 1.43.0 ``                           |
| [`97397e80`](https://github.com/NixOS/nixpkgs/commit/97397e80ac16c2ee1fabe51752a6cb19d691d480) | `` python3Packages.mypy-boto3-savingsplans: 1.42.62 -> 1.43.0 ``                       |
| [`1f720a15`](https://github.com/NixOS/nixpkgs/commit/1f720a15fd6137b36d7d15823a0628c278ce639c) | `` python3Packages.mypy-boto3-sagemaker-runtime: 1.42.54 -> 1.43.0 ``                  |
| [`a509303d`](https://github.com/NixOS/nixpkgs/commit/a509303d4a59a68bf114ef7396fcf3a215ffdc65) | `` python3Packages.mypy-boto3-sagemaker-metrics: 1.42.3 -> 1.43.0 ``                   |
| [`f0e64a82`](https://github.com/NixOS/nixpkgs/commit/f0e64a827691b3d0c560b1d95183590a930d7e57) | `` python3Packages.mypy-boto3-sagemaker-geospatial: 1.42.3 -> 1.43.0 ``                |
| [`9eb4bd36`](https://github.com/NixOS/nixpkgs/commit/9eb4bd36f05f3f0567ffe221311a440fcce390fa) | `` python3Packages.mypy-boto3-sagemaker-featurestore-runtime: 1.42.3 -> 1.43.0 ``      |
| [`5b3439f6`](https://github.com/NixOS/nixpkgs/commit/5b3439f65366a76a59095404bc83f3a8a758213c) | `` python3Packages.mypy-boto3-sagemaker-edge: 1.42.3 -> 1.43.0 ``                      |
| [`823cbe6e`](https://github.com/NixOS/nixpkgs/commit/823cbe6eb3c401dff91459f3c51cc89ad805d497) | `` python3Packages.mypy-boto3-sagemaker-a2i-runtime: 1.42.3 -> 1.43.0 ``               |
| [`1dbf4424`](https://github.com/NixOS/nixpkgs/commit/1dbf442495f97bdb7884066aec058c30c32f437c) | `` python3Packages.mypy-boto3-sagemaker: 1.42.97 -> 1.43.0 ``                          |
| [`db49d5a7`](https://github.com/NixOS/nixpkgs/commit/db49d5a7b7891aab3f12b091f058de13d1c981d6) | `` python3Packages.mypy-boto3-s3outposts: 1.42.3 -> 1.43.0 ``                          |
| [`52297555`](https://github.com/NixOS/nixpkgs/commit/52297555ea31be8c244088a74141af81436854d2) | `` python3Packages.mypy-boto3-s3control: 1.42.94 -> 1.43.0 ``                          |
| [`06c93cd1`](https://github.com/NixOS/nixpkgs/commit/06c93cd108785250c1336e5434d2d9dab0d23d63) | `` python3Packages.mypy-boto3-s3: 1.42.94 -> 1.43.0 ``                                 |
| [`c580c378`](https://github.com/NixOS/nixpkgs/commit/c580c3787dffc1d093c880bb049b07db1e80e90d) | `` python3Packages.mypy-boto3-rum: 1.42.3 -> 1.43.0 ``                                 |
| [`e3d6ba5f`](https://github.com/NixOS/nixpkgs/commit/e3d6ba5f25fcc01c35bf5f452cca32eb5e05ba11) | `` python3Packages.mypy-boto3-route53resolver: 1.42.10 -> 1.43.0 ``                    |
| [`cc0f19ab`](https://github.com/NixOS/nixpkgs/commit/cc0f19abf2572b01190f6dde0678aa1338f1bc7e) | `` python3Packages.mypy-boto3-route53domains: 1.42.3 -> 1.43.0 ``                      |
| [`8685e5e6`](https://github.com/NixOS/nixpkgs/commit/8685e5e679c69f1cffb381882c4c9f0936dc15a0) | `` python3Packages.mypy-boto3-route53-recovery-readiness: 1.42.3 -> 1.43.0 ``          |
| [`1a62d52a`](https://github.com/NixOS/nixpkgs/commit/1a62d52a2074a7c4e09c49a92bcb8e9785503476) | `` python3Packages.mypy-boto3-route53-recovery-control-config: 1.42.3 -> 1.43.0 ``     |
| [`51e4148d`](https://github.com/NixOS/nixpkgs/commit/51e4148d5c6575d8e973f98bb075e4f2b9ba9e98) | `` python3Packages.mypy-boto3-route53-recovery-cluster: 1.42.3 -> 1.43.0 ``            |
| [`8e166e64`](https://github.com/NixOS/nixpkgs/commit/8e166e645776881ac4177fbb7648dc2e27e58c20) | `` python3Packages.mypy-boto3-route53: 1.42.6 -> 1.43.0 ``                             |
| [`2e80f758`](https://github.com/NixOS/nixpkgs/commit/2e80f758ea3ff8c07011e390f992b92642335a2b) | `` python3Packages.mypy-boto3-rolesanywhere: 1.42.5 -> 1.43.0 ``                       |
| [`486228a9`](https://github.com/NixOS/nixpkgs/commit/486228a95f7523028b8912fd9830f053e2023beb) | `` python3Packages.mypy-boto3-resourcegroupstaggingapi: 1.42.3 -> 1.43.0 ``            |
| [`b2497769`](https://github.com/NixOS/nixpkgs/commit/b249776967794da497fe0e1567d585b56e1eb7b6) | `` python3Packages.mypy-boto3-resource-groups: 1.42.3 -> 1.43.0 ``                     |
| [`1efa43ac`](https://github.com/NixOS/nixpkgs/commit/1efa43accb49a5035d9aba77ce13527c430f92cd) | `` python3Packages.mypy-boto3-resource-explorer-2: 1.42.30 -> 1.43.0 ``                |
| [`d1fda66c`](https://github.com/NixOS/nixpkgs/commit/d1fda66cf6165e5ff23a66291aaba5dcc0e7e290) | `` python3Packages.mypy-boto3-resiliencehub: 1.42.3 -> 1.43.0 ``                       |
| [`1438d0cf`](https://github.com/NixOS/nixpkgs/commit/1438d0cfb35689f9129102692a2bce20293b1ac8) | `` python3Packages.mypy-boto3-rekognition: 1.42.3 -> 1.43.0 ``                         |
| [`e997c953`](https://github.com/NixOS/nixpkgs/commit/e997c95308bb3a1969fa16fb753c27c427c4fb7a) | `` python3Packages.mypy-boto3-redshift-serverless: 1.42.28 -> 1.43.0 ``                |
| [`1d9af1ae`](https://github.com/NixOS/nixpkgs/commit/1d9af1aed5e076bbc124c9df8f23e08c0a70e44d) | `` python3Packages.mypy-boto3-redshift-data: 1.42.87 -> 1.43.0 ``                      |
| [`d003a77e`](https://github.com/NixOS/nixpkgs/commit/d003a77eced2ae7169405677136965ed6ec59734) | `` python3Packages.mypy-boto3-redshift: 1.42.42 -> 1.43.0 ``                           |
| [`ddb62b95`](https://github.com/NixOS/nixpkgs/commit/ddb62b95ead4de01451f9a3fb50257189e19eba1) | `` python3Packages.mypy-boto3-rds-data: 1.42.3 -> 1.43.0 ``                            |
| [`ed35bde4`](https://github.com/NixOS/nixpkgs/commit/ed35bde49bdba817f9707d43b3f269e7b794c73b) | `` python3Packages.mypy-boto3-rds: 1.42.90 -> 1.43.0 ``                                |
| [`92e71f07`](https://github.com/NixOS/nixpkgs/commit/92e71f077ef34e157345ba92ba1e6a13dc63854e) | `` python3Packages.mypy-boto3-rbin: 1.42.3 -> 1.43.0 ``                                |
| [`d97f4003`](https://github.com/NixOS/nixpkgs/commit/d97f4003a1cfa44652822edf0b8b9febef0bc4c3) | `` python3Packages.mypy-boto3-ram: 1.42.59 -> 1.43.0 ``                                |
| [`e94819b2`](https://github.com/NixOS/nixpkgs/commit/e94819b2760125c34e98d18d6aeda751d0d2c1c6) | `` python3Packages.mypy-boto3-quicksight: 1.42.91 -> 1.43.0 ``                         |
| [`cba0a706`](https://github.com/NixOS/nixpkgs/commit/cba0a70604eb0daeb5d85be8d03aa4e5d209c90b) | `` python3Packages.mypy-boto3-proton: 1.42.3 -> 1.43.0 ``                              |
| [`c6261247`](https://github.com/NixOS/nixpkgs/commit/c6261247227fb6ed69d6ceb64da478815530d1c3) | `` python3Packages.mypy-boto3-pricing: 1.42.82 -> 1.43.0 ``                            |
| [`209f563d`](https://github.com/NixOS/nixpkgs/commit/209f563d2b31a5d82a7e65f5a22b85298839e517) | `` python3Packages.mypy-boto3-polly: 1.42.76 -> 1.43.0 ``                              |
| [`75bf11f3`](https://github.com/NixOS/nixpkgs/commit/75bf11f303a916fa2561120ad710e764f49803d1) | `` python3Packages.mypy-boto3-pipes: 1.42.3 -> 1.43.0 ``                               |
| [`96d28ff5`](https://github.com/NixOS/nixpkgs/commit/96d28ff549c5353dea6dc0a4b21d10ee6c730b40) | `` python3Packages.mypy-boto3-pinpoint-sms-voice-v2: 1.42.80 -> 1.43.0 ``              |
| [`e84b0880`](https://github.com/NixOS/nixpkgs/commit/e84b088083fd3ec40ecda646b4da1f573f05bf71) | `` python3Packages.mypy-boto3-pinpoint-sms-voice: 1.42.3 -> 1.43.0 ``                  |
| [`54fceb62`](https://github.com/NixOS/nixpkgs/commit/54fceb62c7f7f98f8da92a6c982aa2a6697b5db5) | `` python3Packages.mypy-boto3-pinpoint-email: 1.42.3 -> 1.43.0 ``                      |
| [`5dca57fb`](https://github.com/NixOS/nixpkgs/commit/5dca57fb0a53bf39e662fe366c23002c34992de8) | `` python3Packages.mypy-boto3-pinpoint: 1.42.3 -> 1.43.0 ``                            |
| [`e99a2fbd`](https://github.com/NixOS/nixpkgs/commit/e99a2fbdc2182fdd389bb591291f36a275dc5e2b) | `` python3Packages.mypy-boto3-pi: 1.42.3 -> 1.43.0 ``                                  |
| [`d3bcfcb0`](https://github.com/NixOS/nixpkgs/commit/d3bcfcb0e93638993e6b5cafd1e017fb3355aa88) | `` python3Packages.mypy-boto3-personalize-runtime: 1.42.3 -> 1.43.0 ``                 |
| [`e37fbdff`](https://github.com/NixOS/nixpkgs/commit/e37fbdfff4e55f1fc10f5ca45a9463c54ed9097f) | `` python3Packages.mypy-boto3-personalize-events: 1.42.3 -> 1.43.0 ``                  |
| [`52e5a407`](https://github.com/NixOS/nixpkgs/commit/52e5a4070a787be4356fbe51b5fdb9b827e13315) | `` python3Packages.mypy-boto3-personalize: 1.42.3 -> 1.43.0 ``                         |
| [`32e3376a`](https://github.com/NixOS/nixpkgs/commit/32e3376ae3167ed43dca0f8ac25bf55e4cb35533) | `` python3Packages.mypy-boto3-pca-connector-ad: 1.42.3 -> 1.43.0 ``                    |
| [`fb18236a`](https://github.com/NixOS/nixpkgs/commit/fb18236ad7a37a42d075027b7e902ba4f4bfde2c) | `` python3Packages.mypy-boto3-payment-cryptography-data: 1.42.12 -> 1.43.0 ``          |
| [`d6c9222c`](https://github.com/NixOS/nixpkgs/commit/d6c9222ca92250334fd1f0de0a985174971e4ca2) | `` python3Packages.mypy-boto3-payment-cryptography: 1.42.83 -> 1.43.0 ``               |
| [`a912e975`](https://github.com/NixOS/nixpkgs/commit/a912e9758514022db786d82403510ce53db8244d) | `` python3Packages.mypy-boto3-panorama: 1.42.3 -> 1.43.0 ``                            |
| [`0e414c90`](https://github.com/NixOS/nixpkgs/commit/0e414c902478b216a8eb7c6aff534b89cd9431e9) | `` python3Packages.mypy-boto3-outposts: 1.42.86 -> 1.43.0 ``                           |
| [`40c214ad`](https://github.com/NixOS/nixpkgs/commit/40c214ad0af45655c6232f3fc654dabb7a292200) | `` python3Packages.mypy-boto3-osis: 1.42.94 -> 1.43.0 ``                               |
| [`c61867c7`](https://github.com/NixOS/nixpkgs/commit/c61867c70a9e1b9c59aa1a269599f3ed803e2b11) | `` python3Packages.mypy-boto3-organizations: 1.42.83 -> 1.43.0 ``                      |
| [`bf305ffe`](https://github.com/NixOS/nixpkgs/commit/bf305ffe8362bc935824112b7d185600aa67da20) | `` python3Packages.mypy-boto3-opensearchserverless: 1.42.75 -> 1.43.0 ``               |
| [`ee895b8d`](https://github.com/NixOS/nixpkgs/commit/ee895b8d65a1366c6d97e9e2975a205793f8a0e8) | `` python3Packages.mypy-boto3-opensearch: 1.42.97 -> 1.43.0 ``                         |
| [`0cb783a5`](https://github.com/NixOS/nixpkgs/commit/0cb783a5b9a29c162fc00c284fd6f63ac8dbfb43) | `` python3Packages.mypy-boto3-omics: 1.42.97 -> 1.43.0 ``                              |
| [`fb273712`](https://github.com/NixOS/nixpkgs/commit/fb273712eb41a7da6215ae90981157abc9246d31) | `` python3Packages.mypy-boto3-oam: 1.42.3 -> 1.43.0 ``                                 |
| [`5abba088`](https://github.com/NixOS/nixpkgs/commit/5abba088baa569014da830ce6aae0bd0d24f32b7) | `` python3Packages.mypy-boto3-networkmanager: 1.42.3 -> 1.43.0 ``                      |
| [`bd0964bb`](https://github.com/NixOS/nixpkgs/commit/bd0964bb075aedc56fa4af8ea529be6d6fb94e17) | `` python3Packages.mypy-boto3-network-firewall: 1.42.93 -> 1.43.0 ``                   |
| [`a44a31f2`](https://github.com/NixOS/nixpkgs/commit/a44a31f2318a4068e4eef200a59e8d1ca6e8b5a6) | `` python3Packages.mypy-boto3-neptunedata: 1.42.78 -> 1.43.0 ``                        |
| [`ff97ec13`](https://github.com/NixOS/nixpkgs/commit/ff97ec13a9b830e9a108ba374ab56894c4e2ea29) | `` python3Packages.mypy-boto3-neptune: 1.42.91 -> 1.43.0 ``                            |
| [`dc81e484`](https://github.com/NixOS/nixpkgs/commit/dc81e484381b5876d7b5f88cfcd050c804b57bb4) | `` python3Packages.mypy-boto3-mwaa: 1.42.3 -> 1.43.0 ``                                |
| [`a3efe782`](https://github.com/NixOS/nixpkgs/commit/a3efe7828cb7cd0ca5107c7700bbbf144847e58a) | `` python3Packages.mypy-boto3-mturk: 1.42.3 -> 1.43.0 ``                               |
| [`734b226c`](https://github.com/NixOS/nixpkgs/commit/734b226c2fa2129d3197bb45403b155c77aeae14) | `` python3Packages.mypy-boto3-mq: 1.42.3 -> 1.43.0 ``                                  |
| [`a8e9ad0d`](https://github.com/NixOS/nixpkgs/commit/a8e9ad0d48cdb0514bee89f8c93a1d0addb31029) | `` python3Packages.mypy-boto3-migrationhubstrategy: 1.42.3 -> 1.43.0 ``                |
| [`dffbea48`](https://github.com/NixOS/nixpkgs/commit/dffbea48d78d371a218990a350f61be879b7a8d0) | `` python3Packages.mypy-boto3-migrationhuborchestrator: 1.42.3 -> 1.43.0 ``            |
| [`60485dc2`](https://github.com/NixOS/nixpkgs/commit/60485dc267a704f1f92ae0a1c24ece44d4abcc72) | `` python3Packages.mypy-boto3-migrationhub-config: 1.42.3 -> 1.43.0 ``                 |
| [`4811bdd9`](https://github.com/NixOS/nixpkgs/commit/4811bdd9ec4774abb095e20f87a1a5e732e70b37) | `` python3Packages.mypy-boto3-migration-hub-refactor-spaces: 1.42.3 -> 1.43.0 ``       |
| [`2ef92324`](https://github.com/NixOS/nixpkgs/commit/2ef9232426205f8f29e872caa381d26625f9e72d) | `` python3Packages.mypy-boto3-mgn: 1.42.97 -> 1.43.0 ``                                |
| [`4e44e952`](https://github.com/NixOS/nixpkgs/commit/4e44e952859c07453168b51a26d1885679d698bb) | `` python3Packages.mypy-boto3-mgh: 1.42.3 -> 1.43.0 ``                                 |
| [`9bdcf005`](https://github.com/NixOS/nixpkgs/commit/9bdcf0051610bed3c6a048d5fae94755bb673dd6) | `` python3Packages.mypy-boto3-meteringmarketplace: 1.42.58 -> 1.43.0 ``                |
| [`c6e25e1f`](https://github.com/NixOS/nixpkgs/commit/c6e25e1f41cb175f606c646287be0a078137de4c) | `` python3Packages.mypy-boto3-memorydb: 1.42.3 -> 1.43.0 ``                            |
| [`21a13143`](https://github.com/NixOS/nixpkgs/commit/21a1314351b1ecabaf74e891405ebee1b6dd0eea) | `` python3Packages.mypy-boto3-medical-imaging: 1.42.81 -> 1.43.0 ``                    |
| [`3d8700f9`](https://github.com/NixOS/nixpkgs/commit/3d8700f995f421e76ed86e6159a5b93c80c4fea3) | `` python3Packages.mypy-boto3-mediatailor: 1.42.84 -> 1.43.0 ``                        |
| [`92989b08`](https://github.com/NixOS/nixpkgs/commit/92989b08e25c4e3786ff1502f43e76d9baf4e5e8) | `` python3Packages.mypy-boto3-mediastore-data: 1.42.3 -> 1.43.0 ``                     |
| [`079a1c96`](https://github.com/NixOS/nixpkgs/commit/079a1c9613972cd8a8ff7ae55883e7e82a23a7b0) | `` python3Packages.mypy-boto3-mediastore: 1.42.3 -> 1.43.0 ``                          |
| [`1dbbc232`](https://github.com/NixOS/nixpkgs/commit/1dbbc232dabd14993244536be71b10bf39366f17) | `` python3Packages.mypy-boto3-mediapackagev2: 1.42.75 -> 1.43.0 ``                     |
| [`087a5b01`](https://github.com/NixOS/nixpkgs/commit/087a5b01dc82e7217323a76e2b4b0bf45a20cebf) | `` python3Packages.mypy-boto3-mediapackage-vod: 1.42.3 -> 1.43.0 ``                    |
| [`3194dd75`](https://github.com/NixOS/nixpkgs/commit/3194dd750d1ddd69e5a924ecdf7523fe8f1c8b29) | `` python3Packages.mypy-boto3-mediapackage: 1.42.3 -> 1.43.0 ``                        |
| [`46c0a43e`](https://github.com/NixOS/nixpkgs/commit/46c0a43e9b8c1be1081bcb2c2b62733567708956) | `` python3Packages.mypy-boto3-medialive: 1.42.86 -> 1.43.0 ``                          |
| [`c20aee63`](https://github.com/NixOS/nixpkgs/commit/c20aee63dbab24e41d74a50f6f80ce024797b975) | `` python3Packages.mypy-boto3-mediaconvert: 1.42.90 -> 1.43.0 ``                       |
| [`ff98c57c`](https://github.com/NixOS/nixpkgs/commit/ff98c57c98e1f1953662ad8a0d66c4e590625107) | `` python3Packages.mypy-boto3-mediaconnect: 1.42.87 -> 1.43.0 ``                       |
| [`7678cfdc`](https://github.com/NixOS/nixpkgs/commit/7678cfdca2bd01793afbfe9e3379f2fd67cb3b31) | `` python3Packages.mypy-boto3-marketplacecommerceanalytics: 1.42.3 -> 1.43.0 ``        |
| [`8e6be09c`](https://github.com/NixOS/nixpkgs/commit/8e6be09cd3e7bd6f8c46fb5ba41b019d1105ef3c) | `` python3Packages.mypy-boto3-marketplace-entitlement: 1.42.93 -> 1.43.0 ``            |
| [`c738c720`](https://github.com/NixOS/nixpkgs/commit/c738c720825be56f4e8bcac874cb28fbdbe8693e) | `` python3Packages.mypy-boto3-marketplace-catalog: 1.42.41 -> 1.43.0 ``                |
| [`c9f34d86`](https://github.com/NixOS/nixpkgs/commit/c9f34d865392e3fe6a943e6d6ae6d080339d0fba) | `` python3Packages.mypy-boto3-managedblockchain-query: 1.42.3 -> 1.43.0 ``             |
| [`ea18000b`](https://github.com/NixOS/nixpkgs/commit/ea18000b7ca26734424ee83745bbe4fc7c101d78) | `` python3Packages.mypy-boto3-managedblockchain: 1.42.3 -> 1.43.0 ``                   |
| [`80b29332`](https://github.com/NixOS/nixpkgs/commit/80b29332b1de44f574a6818611750e68c101dc87) | `` python3Packages.mypy-boto3-macie2: 1.42.89 -> 1.43.0 ``                             |
| [`ef95b159`](https://github.com/NixOS/nixpkgs/commit/ef95b159b8aaae1e91cdc44a3f598bd76fd4d8ee) | `` python3Packages.mypy-boto3-machinelearning: 1.42.3 -> 1.43.0 ``                     |
| [`49672314`](https://github.com/NixOS/nixpkgs/commit/4967231447f3a8f93e85b365d2b83e93316b9fba) | `` python3Packages.mypy-boto3-m2: 1.42.3 -> 1.43.0 ``                                  |
| [`b3d915de`](https://github.com/NixOS/nixpkgs/commit/b3d915de6422bcd52264134918000e42e36c725b) | `` python3Packages.mypy-boto3-lookoutequipment: 1.42.3 -> 1.43.0 ``                    |
| [`95b3c467`](https://github.com/NixOS/nixpkgs/commit/95b3c4672e15db88f76b9f31d1e9fa3e465ede62) | `` python3Packages.mypy-boto3-logs: 1.42.97 -> 1.43.0 ``                               |
| [`a6cf9db8`](https://github.com/NixOS/nixpkgs/commit/a6cf9db8f725cf5affcfdbf7763faeb28e98c92b) | `` python3Packages.mypy-boto3-location: 1.42.92 -> 1.43.0 ``                           |
| [`1111a7bb`](https://github.com/NixOS/nixpkgs/commit/1111a7bb24f7682d09f621e626b069872a9d69c8) | `` python3Packages.mypy-boto3-lightsail: 1.42.84 -> 1.43.0 ``                          |
| [`10de1c76`](https://github.com/NixOS/nixpkgs/commit/10de1c7611ddde29498c1c8fe2ca03c160e79d09) | `` python3Packages.mypy-boto3-license-manager-user-subscriptions: 1.42.3 -> 1.43.0 ``  |
| [`edb7319a`](https://github.com/NixOS/nixpkgs/commit/edb7319a2d225a6dc02e692a14007f6a6079a55c) | `` python3Packages.mypy-boto3-license-manager-linux-subscriptions: 1.42.3 -> 1.43.0 `` |
| [`b9e65696`](https://github.com/NixOS/nixpkgs/commit/b9e656968a31c3e13c6023657777551efa2a9294) | `` python3Packages.mypy-boto3-license-manager: 1.42.3 -> 1.43.0 ``                     |
| [`3e942d9d`](https://github.com/NixOS/nixpkgs/commit/3e942d9d9037bce952f1f4c5fc02f61880e69ad6) | `` python3Packages.mypy-boto3-lexv2-runtime: 1.42.3 -> 1.43.0 ``                       |
| [`ffcd6aa6`](https://github.com/NixOS/nixpkgs/commit/ffcd6aa644f35f5924fb0032a1bf204ae57e4469) | `` python3Packages.mypy-boto3-lexv2-models: 1.42.65 -> 1.43.0 ``                       |
| [`9b29d960`](https://github.com/NixOS/nixpkgs/commit/9b29d9607ec4876702c4eb97aa2441e9e7138b21) | `` python3Packages.mypy-boto3-lex-runtime: 1.42.3 -> 1.43.0 ``                         |
| [`b2f40702`](https://github.com/NixOS/nixpkgs/commit/b2f40702dfaa6f6d03a0efa14371ba59f902a88c) | `` python3Packages.mypy-boto3-lex-models: 1.42.3 -> 1.43.0 ``                          |
| [`bfbf95f5`](https://github.com/NixOS/nixpkgs/commit/bfbf95f5da8060364619afdc900a220f681dc85f) | `` python3Packages.mypy-boto3-lambda: 1.42.94 -> 1.43.0 ``                             |
| [`e6fd3c1f`](https://github.com/NixOS/nixpkgs/commit/e6fd3c1f5fd3b78839cc50b7640fa755d67147a0) | `` python3Packages.mypy-boto3-lakeformation: 1.42.79 -> 1.43.0 ``                      |
| [`2d7ebe7c`](https://github.com/NixOS/nixpkgs/commit/2d7ebe7c1629331f376545990ec318904c3eac46) | `` python3Packages.mypy-boto3-kms: 1.42.97 -> 1.43.0 ``                                |
| [`65dac791`](https://github.com/NixOS/nixpkgs/commit/65dac79176da63c0f18cdb4c5f8d7f935c9322bb) | `` python3Packages.mypy-boto3-kinesisvideo: 1.42.3 -> 1.43.0 ``                        |
| [`cb0ad295`](https://github.com/NixOS/nixpkgs/commit/cb0ad295c3de61b33c27183b6e48170007c7d576) | `` python3Packages.mypy-boto3-kinesisanalyticsv2: 1.42.80 -> 1.43.0 ``                 |
| [`9ab9342b`](https://github.com/NixOS/nixpkgs/commit/9ab9342bac9d8f8a1797d8bef8d8e12666cdd58a) | `` python3Packages.mypy-boto3-kinesisanalytics: 1.42.3 -> 1.43.0 ``                    |
| [`d9bee388`](https://github.com/NixOS/nixpkgs/commit/d9bee3887061ac9c79e89124ea9e6fb725b44078) | `` python3Packages.mypy-boto3-kinesis-video-webrtc-storage: 1.42.3 -> 1.43.0 ``        |
| [`3dcd9d1c`](https://github.com/NixOS/nixpkgs/commit/3dcd9d1c60e859afa71855ece7258806a913460a) | `` python3Packages.mypy-boto3-kinesis-video-signaling: 1.42.3 -> 1.43.0 ``             |
| [`fd933b91`](https://github.com/NixOS/nixpkgs/commit/fd933b9148cc678c8e51f73114dcc150fefae76e) | `` python3Packages.mypy-boto3-kinesis-video-media: 1.42.3 -> 1.43.0 ``                 |
| [`fccaf8d4`](https://github.com/NixOS/nixpkgs/commit/fccaf8d46f74e754518bc1c57ea920b594b85166) | `` python3Packages.mypy-boto3-kinesis-video-archived-media: 1.42.3 -> 1.43.0 ``        |
| [`15d1121f`](https://github.com/NixOS/nixpkgs/commit/15d1121f344c4c28bb8bbf13d86711bbc22aab52) | `` python3Packages.mypy-boto3-kinesis: 1.42.41 -> 1.43.0 ``                            |
| [`98e1bd45`](https://github.com/NixOS/nixpkgs/commit/98e1bd45dc7720d07cb75b4bf4f3924f2ac5cd2e) | `` python3Packages.mypy-boto3-keyspaces: 1.42.31 -> 1.43.0 ``                          |
| [`a6f125fd`](https://github.com/NixOS/nixpkgs/commit/a6f125fd1abcd65589f93119b4bdb7925b93365e) | `` python3Packages.mypy-boto3-kendra-ranking: 1.42.3 -> 1.43.0 ``                      |
| [`35503450`](https://github.com/NixOS/nixpkgs/commit/35503450edad108b0d90e6dc45ee2891933f3010) | `` python3Packages.mypy-boto3-kendra: 1.42.3 -> 1.43.0 ``                              |
| [`0a65c9bc`](https://github.com/NixOS/nixpkgs/commit/0a65c9bc399489c032298b32329a11b967bf6d96) | `` python3Packages.mypy-boto3-kafkaconnect: 1.42.47 -> 1.43.0 ``                       |
| [`1481cdc7`](https://github.com/NixOS/nixpkgs/commit/1481cdc77b364293435651c50f7f53bade9e08a6) | `` python3Packages.mypy-boto3-kafka: 1.42.92 -> 1.43.0 ``                              |
| [`b051fa37`](https://github.com/NixOS/nixpkgs/commit/b051fa37112eff395ed9aa57d1a8c7f2f66d18d6) | `` python3Packages.mypy-boto3-ivschat: 1.42.3 -> 1.43.0 ``                             |
| [`9ef7b88e`](https://github.com/NixOS/nixpkgs/commit/9ef7b88e2e1c0713f7e70bbc444a74d6b01b664c) | `` python3Packages.mypy-boto3-ivs-realtime: 1.42.86 -> 1.43.0 ``                       |
| [`e5857dde`](https://github.com/NixOS/nixpkgs/commit/e5857dde25c6bd39f56c431da6112f2651715d75) | `` python3Packages.mypy-boto3-ivs: 1.42.97 -> 1.43.0 ``                                |
| [`0861b418`](https://github.com/NixOS/nixpkgs/commit/0861b418b1350a64455127809a8612478581e997) | `` python3Packages.mypy-boto3-iotwireless: 1.42.94 -> 1.43.0 ``                        |
| [`038b72b5`](https://github.com/NixOS/nixpkgs/commit/038b72b5f67964cc3d8e9451c8b3ec17382345c2) | `` python3Packages.mypy-boto3-iottwinmaker: 1.42.3 -> 1.43.0 ``                        |
| [`399183b2`](https://github.com/NixOS/nixpkgs/commit/399183b2cb9ebddf119c9e3c66e77a3c87143641) | `` python3Packages.mypy-boto3-iotthingsgraph: 1.42.3 -> 1.43.0 ``                      |
| [`e55b3e6a`](https://github.com/NixOS/nixpkgs/commit/e55b3e6ae01700f012e38b71ad91c170419560ee) | `` python3Packages.mypy-boto3-iotsitewise: 1.42.3 -> 1.43.0 ``                         |
| [`2321cc3b`](https://github.com/NixOS/nixpkgs/commit/2321cc3bef3ad9f030b79ac8e94135596b12b1f6) | `` python3Packages.mypy-boto3-iotsecuretunneling: 1.42.3 -> 1.43.0 ``                  |
| [`5c809410`](https://github.com/NixOS/nixpkgs/commit/5c8094101b744e2e1cdae7f8d9999f405a8cebc9) | `` python3Packages.mypy-boto3-iotfleetwise: 1.42.3 -> 1.43.0 ``                        |
| [`59e4f6d3`](https://github.com/NixOS/nixpkgs/commit/59e4f6d34d12d54d2176ca86fdebdfdad63ff62c) | `` python3Packages.mypy-boto3-iotevents-data: 1.42.3 -> 1.43.0 ``                      |
| [`c5b9aec9`](https://github.com/NixOS/nixpkgs/commit/c5b9aec940a26b1468b3028b31d95b2afc771b18) | `` python3Packages.mypy-boto3-iotevents: 1.42.3 -> 1.43.0 ``                           |
| [`63ebf3a5`](https://github.com/NixOS/nixpkgs/commit/63ebf3a5fced21c36b97483d6c61c5998b68cb4b) | `` python3Packages.mypy-boto3-iotdeviceadvisor: 1.42.3 -> 1.43.0 ``                    |
| [`dcad0ab9`](https://github.com/NixOS/nixpkgs/commit/dcad0ab9fb0bdf557f183bf59a4424ab296d4f63) | `` python3Packages.mypy-boto3-iot-jobs-data: 1.42.3 -> 1.43.0 ``                       |
| [`64ca4f8e`](https://github.com/NixOS/nixpkgs/commit/64ca4f8e095f5d4ba432a835d12f25151222d1f4) | `` python3Packages.mypy-boto3-iot-data: 1.42.3 -> 1.43.0 ``                            |
| [`a6a767b8`](https://github.com/NixOS/nixpkgs/commit/a6a767b84680514054c5f10e07a31d6c4ecaa3a6) | `` python3Packages.mypy-boto3-iot: 1.42.14 -> 1.43.0 ``                                |
| [`83a9d035`](https://github.com/NixOS/nixpkgs/commit/83a9d035112032375a7fb47e32813a99adb229c1) | `` python3Packages.mypy-boto3-internetmonitor: 1.42.3 -> 1.43.0 ``                     |
| [`39a85907`](https://github.com/NixOS/nixpkgs/commit/39a859077438eb996f180534002c4d237bb2f273) | `` python3Packages.mypy-boto3-inspector2: 1.42.49 -> 1.43.0 ``                         |
| [`176c1ed7`](https://github.com/NixOS/nixpkgs/commit/176c1ed78e9bf655b838c2cfb0baa89d5fe00f6c) | `` python3Packages.mypy-boto3-inspector: 1.42.3 -> 1.43.0 ``                           |
| [`3a060088`](https://github.com/NixOS/nixpkgs/commit/3a060088e0c38fac13722ef3cb2d31965e244d57) | `` python3Packages.mypy-boto3-importexport: 1.42.3 -> 1.43.0 ``                        |
| [`582f3eed`](https://github.com/NixOS/nixpkgs/commit/582f3eed2cb116e2ea5434328e85e145e95994db) | `` python3Packages.mypy-boto3-imagebuilder: 1.42.91 -> 1.43.0 ``                       |
| [`a158bcf5`](https://github.com/NixOS/nixpkgs/commit/a158bcf5066f6e8752db84bb03a463e558b25644) | `` python3Packages.mypy-boto3-identitystore: 1.42.20 -> 1.43.0 ``                      |
| [`e08550c3`](https://github.com/NixOS/nixpkgs/commit/e08550c3d252969844e92bddf687c784c1bcc137) | `` python3Packages.mypy-boto3-iam: 1.42.64 -> 1.43.0 ``                                |
| [`58a2420a`](https://github.com/NixOS/nixpkgs/commit/58a2420a87380f16b0c187538e1fa3c8705d71e3) | `` python3Packages.mypy-boto3-healthlake: 1.42.3 -> 1.43.0 ``                          |
| [`1afc1b6c`](https://github.com/NixOS/nixpkgs/commit/1afc1b6c4665ac45a2d961bfcba2a00e3e19b4ff) | `` python3Packages.mypy-boto3-health: 1.42.59 -> 1.43.0 ``                             |
| [`3550707b`](https://github.com/NixOS/nixpkgs/commit/3550707b9a8e41dc512b18c5c3962f6041e5e640) | `` python3Packages.mypy-boto3-guardduty: 1.42.92 -> 1.43.0 ``                          |
| [`c00671c5`](https://github.com/NixOS/nixpkgs/commit/c00671c5b7f05cd249f1b17458c5eed269b9d378) | `` python3Packages.mypy-boto3-groundstation: 1.42.91 -> 1.43.0 ``                      |
| [`add9ff12`](https://github.com/NixOS/nixpkgs/commit/add9ff12db871430343a59b8280d24ec4a545590) | `` python3Packages.mypy-boto3-greengrassv2: 1.42.3 -> 1.43.0 ``                        |
| [`d35dd8d1`](https://github.com/NixOS/nixpkgs/commit/d35dd8d148b0c92e277741e2a49bc190049872ab) | `` python3Packages.mypy-boto3-greengrass: 1.42.3 -> 1.43.0 ``                          |
| [`c2179046`](https://github.com/NixOS/nixpkgs/commit/c2179046262b4e5bab7c283a2803f180b2a10f3f) | `` python3Packages.mypy-boto3-grafana: 1.42.51 -> 1.43.0 ``                            |
| [`4156b1e0`](https://github.com/NixOS/nixpkgs/commit/4156b1e0d3f351741aba8c5e87a7118763295d20) | `` python3Packages.mypy-boto3-glue: 1.42.97 -> 1.43.0 ``                               |
| [`5bfedf4a`](https://github.com/NixOS/nixpkgs/commit/5bfedf4aee47349a6991866fbcb54b534970d8f8) | `` python3Packages.mypy-boto3-globalaccelerator: 1.42.3 -> 1.43.0 ``                   |
| [`b5ef2357`](https://github.com/NixOS/nixpkgs/commit/b5ef2357d9e1b9dae7f2859293e234dc6a53bdcb) | `` python3Packages.mypy-boto3-glacier: 1.42.30 -> 1.43.0 ``                            |
| [`3c10fb8f`](https://github.com/NixOS/nixpkgs/commit/3c10fb8f7872ea4fd027f74ca36b2f09a3dde37f) | `` python3Packages.mypy-boto3-gamelift: 1.42.93 -> 1.43.0 ``                           |
| [`2816cc5e`](https://github.com/NixOS/nixpkgs/commit/2816cc5e1c368cd478d1f9eaf96a95a029a63a5c) | `` python3Packages.mypy-boto3-fsx: 1.42.3 -> 1.43.0 ``                                 |
| [`ec4e35fc`](https://github.com/NixOS/nixpkgs/commit/ec4e35fcc2ed575f83f3355a9f2e51c5272a5471) | `` python3Packages.mypy-boto3-frauddetector: 1.42.3 -> 1.43.0 ``                       |
| [`ce74d8a2`](https://github.com/NixOS/nixpkgs/commit/ce74d8a2cba870f18286c985b3529a592f2173df) | `` python3Packages.mypy-boto3-forecastquery: 1.42.3 -> 1.43.0 ``                       |
| [`e85b488a`](https://github.com/NixOS/nixpkgs/commit/e85b488ad7bb23033e63115265c18f94628ad16e) | `` python3Packages.mypy-boto3-forecast: 1.42.3 -> 1.43.0 ``                            |
| [`b19e751d`](https://github.com/NixOS/nixpkgs/commit/b19e751d692872a60ff1565dfc3152e1efc90528) | `` python3Packages.mypy-boto3-fms: 1.42.3 -> 1.43.0 ``                                 |
| [`7a87f961`](https://github.com/NixOS/nixpkgs/commit/7a87f96168e3d409896cb6a5435af38c1ed44423) | `` python3Packages.mypy-boto3-fis: 1.42.3 -> 1.43.0 ``                                 |
| [`ab605252`](https://github.com/NixOS/nixpkgs/commit/ab605252f368e41fd33b054448197c1db708bacb) | `` python3Packages.mypy-boto3-firehose: 1.42.3 -> 1.43.0 ``                            |
| [`ba918f19`](https://github.com/NixOS/nixpkgs/commit/ba918f190549b5a6f2549bc0e565db598b12a46c) | `` python3Packages.mypy-boto3-finspace-data: 1.42.3 -> 1.43.0 ``                       |
| [`8daf5b88`](https://github.com/NixOS/nixpkgs/commit/8daf5b88f420f6e9f19814fa496555f08b0915c8) | `` python3Packages.mypy-boto3-finspace: 1.42.3 -> 1.43.0 ``                            |
| [`6e53fecc`](https://github.com/NixOS/nixpkgs/commit/6e53feccfbc9f7917e69d794a58d5ed8ce10e2ab) | `` python3Packages.mypy-boto3-events: 1.42.3 -> 1.43.0 ``                              |
| [`e3d3129e`](https://github.com/NixOS/nixpkgs/commit/e3d3129ec8549cdc367a874122a6791f4779c7ad) | `` python3Packages.mypy-boto3-es: 1.42.81 -> 1.43.0 ``                                 |
| [`5cba2c79`](https://github.com/NixOS/nixpkgs/commit/5cba2c7959b84d153342a1f8da2cecd41aecfd8a) | `` python3Packages.mypy-boto3-entityresolution: 1.42.10 -> 1.43.0 ``                   |
| [`418dae1d`](https://github.com/NixOS/nixpkgs/commit/418dae1d28173479bd3eb121e6a3673454ef1a80) | `` python3Packages.mypy-boto3-emr-serverless: 1.42.94 -> 1.43.0 ``                     |
| [`e822840d`](https://github.com/NixOS/nixpkgs/commit/e822840daf3476e6412b29f1976d03ff877bf761) | `` python3Packages.mypy-boto3-emr-containers: 1.42.3 -> 1.43.0 ``                      |
| [`c64c1fea`](https://github.com/NixOS/nixpkgs/commit/c64c1feadbf25293d50e076d8829776c9f6ca4c7) | `` python3Packages.mypy-boto3-emr: 1.42.77 -> 1.43.0 ``                                |
| [`56def460`](https://github.com/NixOS/nixpkgs/commit/56def4603d0dbd7e9e06a611d3c5380bd6a742f9) | `` python3Packages.mypy-boto3-elbv2: 1.42.3 -> 1.43.0 ``                               |
| [`7c3b3dd5`](https://github.com/NixOS/nixpkgs/commit/7c3b3dd5b0af913d27db5dbf84db1c34f11adbed) | `` python3Packages.mypy-boto3-elb: 1.42.3 -> 1.43.0 ``                                 |
| [`d357b189`](https://github.com/NixOS/nixpkgs/commit/d357b189f5aca472991d6f2216ba6c96d44ac9f7) | `` python3Packages.mypy-boto3-elasticbeanstalk: 1.42.61 -> 1.43.0 ``                   |
| [`d90821f8`](https://github.com/NixOS/nixpkgs/commit/d90821f8d722b7d67052cda8beed6853c13b4c2c) | `` python3Packages.mypy-boto3-elasticache: 1.42.81 -> 1.43.0 ``                        |
| [`9c884258`](https://github.com/NixOS/nixpkgs/commit/9c884258627589bdb0d65e17b170004a26dba996) | `` python3Packages.mypy-boto3-eks: 1.42.85 -> 1.43.0 ``                                |
| [`b41b0822`](https://github.com/NixOS/nixpkgs/commit/b41b08226e28a7c4e3561bd89a4334e048795c7f) | `` python3Packages.mypy-boto3-efs: 1.42.3 -> 1.43.0 ``                                 |
| [`17ef4518`](https://github.com/NixOS/nixpkgs/commit/17ef4518a8d24251771a3049eef9cf39d9152082) | `` python3Packages.mypy-boto3-ecs: 1.42.94 -> 1.43.0 ``                                |
| [`6e798fd6`](https://github.com/NixOS/nixpkgs/commit/6e798fd65bc358b579d262621599ae32f3a07c35) | `` python3Packages.mypy-boto3-ecr-public: 1.42.3 -> 1.43.0 ``                          |
| [`fe6fc94a`](https://github.com/NixOS/nixpkgs/commit/fe6fc94a69e473ee600d4b63d18213bb4002a78c) | `` python3Packages.mypy-boto3-ecr: 1.42.86 -> 1.43.0 ``                                |
| [`d154597e`](https://github.com/NixOS/nixpkgs/commit/d154597eecce070adce404e9430cf0b0872b5afa) | `` python3Packages.mypy-boto3-ec2-instance-connect: 1.42.3 -> 1.43.0 ``                |
| [`bdd8eb2b`](https://github.com/NixOS/nixpkgs/commit/bdd8eb2b75ecab0841d08c8f4a384d0811ac3d11) | `` python3Packages.mypy-boto3-ec2: 1.42.94 -> 1.43.0 ``                                |
| [`22c88a3c`](https://github.com/NixOS/nixpkgs/commit/22c88a3c0844b06dca8fd62dad4a23f183c270ae) | `` python3Packages.mypy-boto3-ebs: 1.42.3 -> 1.43.0 ``                                 |
| [`cf97c0a0`](https://github.com/NixOS/nixpkgs/commit/cf97c0a07046bc8570e13ee7f2a682bd6d2c73c8) | `` python3Packages.mypy-boto3-dynamodbstreams: 1.42.3 -> 1.43.0 ``                     |
| [`5d3ebcd0`](https://github.com/NixOS/nixpkgs/commit/5d3ebcd0cd87617ecc23ce901e02f08088291ea2) | `` python3Packages.mypy-boto3-dynamodb: 1.42.73 -> 1.43.0 ``                           |
| [`35232b15`](https://github.com/NixOS/nixpkgs/commit/35232b15242ffd299a2a244884c3388d89d38e74) | `` python3Packages.mypy-boto3-ds: 1.42.3 -> 1.43.0 ``                                  |
| [`7f486d8b`](https://github.com/NixOS/nixpkgs/commit/7f486d8ba877551ea3c30675d9ba64ba0276513a) | `` python3Packages.mypy-boto3-drs: 1.42.90 -> 1.43.0 ``                                |
| [`6ee4ea75`](https://github.com/NixOS/nixpkgs/commit/6ee4ea758b8bc21b3e30e52ff1dea160644b70e1) | `` python3Packages.mypy-boto3-docdb-elastic: 1.42.3 -> 1.43.0 ``                       |
| [`b768250a`](https://github.com/NixOS/nixpkgs/commit/b768250a7f43345c396a806021f70c9966a22499) | `` python3Packages.mypy-boto3-docdb: 1.42.3 -> 1.43.0 ``                               |
| [`de096911`](https://github.com/NixOS/nixpkgs/commit/de096911c6ae57a112649061f5625e39a8746a67) | `` python3Packages.mypy-boto3-dms: 1.42.80 -> 1.43.0 ``                                |
| [`eee24585`](https://github.com/NixOS/nixpkgs/commit/eee24585acdf15f110bdac95c97792ecb28f31be) | `` python3Packages.mypy-boto3-dlm: 1.42.84 -> 1.43.0 ``                                |
| [`f8ee5d55`](https://github.com/NixOS/nixpkgs/commit/f8ee5d556ca21b4ac05f26d492eb11a2cf2f53e0) | `` python3Packages.mypy-boto3-discovery: 1.42.3 -> 1.43.0 ``                           |
| [`ef9e6ab4`](https://github.com/NixOS/nixpkgs/commit/ef9e6ab4c4eccb795263e292293c8d03b63f50a1) | `` python3Packages.mypy-boto3-directconnect: 1.42.3 -> 1.43.0 ``                       |
| [`cc116905`](https://github.com/NixOS/nixpkgs/commit/cc116905c35d7446a8ff8d428b3d2ff17c4a6760) | `` python3Packages.mypy-boto3-devops-guru: 1.42.3 -> 1.43.0 ``                         |
| [`d1547879`](https://github.com/NixOS/nixpkgs/commit/d15478793d94810b848a5bdfacfbb5e6223c8f42) | `` python3Packages.mypy-boto3-devicefarm: 1.42.3 -> 1.43.0 ``                          |
| [`4c9e9222`](https://github.com/NixOS/nixpkgs/commit/4c9e9222682107f1f2ab9974672ed45713a50730) | `` python3Packages.mypy-boto3-detective: 1.42.3 -> 1.43.0 ``                           |
| [`a64287d9`](https://github.com/NixOS/nixpkgs/commit/a64287d9a17e727c457aec33a82f280531a122a6) | `` python3Packages.mypy-boto3-dax: 1.42.3 -> 1.43.0 ``                                 |
| [`4e074124`](https://github.com/NixOS/nixpkgs/commit/4e0741242a67dc084f2b67792236fe88ac755d99) | `` python3Packages.mypy-boto3-datasync: 1.42.85 -> 1.43.0 ``                           |
| [`00eafdc9`](https://github.com/NixOS/nixpkgs/commit/00eafdc96de9ceb1ad86ce8050fbe802746b138a) | `` python3Packages.mypy-boto3-datapipeline: 1.42.3 -> 1.43.0 ``                        |
| [`a4d2b57e`](https://github.com/NixOS/nixpkgs/commit/a4d2b57e4d8d37c781a82fd64728d4251a557808) | `` python3Packages.mypy-boto3-dataexchange: 1.42.80 -> 1.43.0 ``                       |
| [`328d6cb1`](https://github.com/NixOS/nixpkgs/commit/328d6cb166eb29d7e178f5c1764d4c32bcbddc35) | `` python3Packages.mypy-boto3-databrew: 1.42.3 -> 1.43.0 ``                            |
| [`850afb13`](https://github.com/NixOS/nixpkgs/commit/850afb13a2bddbc6db37bc1e7956704e90fb7fe0) | `` python3Packages.mypy-boto3-customer-profiles: 1.42.90 -> 1.43.0 ``                  |
| [`7d4256bd`](https://github.com/NixOS/nixpkgs/commit/7d4256bd7cdd9374fa8887e846a630722cafbb4b) | `` python3Packages.mypy-boto3-cur: 1.42.3 -> 1.43.0 ``                                 |
| [`63797a87`](https://github.com/NixOS/nixpkgs/commit/63797a87f9919fafe6fc6cf65c2642ba23ae469c) | `` python3Packages.mypy-boto3-controltower: 1.42.3 -> 1.43.0 ``                        |
| [`6ed6f4c5`](https://github.com/NixOS/nixpkgs/commit/6ed6f4c52989d1b4470755a495bb8022ad584468) | `` python3Packages.mypy-boto3-connectparticipant: 1.42.3 -> 1.43.0 ``                  |
| [`d1b75533`](https://github.com/NixOS/nixpkgs/commit/d1b75533b995d6506f88d1e198d07b185593d6f6) | `` python3Packages.mypy-boto3-connectcases: 1.42.90 -> 1.43.0 ``                       |
| [`306b1f8d`](https://github.com/NixOS/nixpkgs/commit/306b1f8dcc0052861c0ffcea34cf05e56eb197d6) | `` python3Packages.mypy-boto3-connectcampaigns: 1.42.3 -> 1.43.0 ``                    |
| [`2698bc10`](https://github.com/NixOS/nixpkgs/commit/2698bc1030a3d85cdd7240d5b37622cd2dda1ac6) | `` python3Packages.mypy-boto3-connect-contact-lens: 1.42.3 -> 1.43.0 ``                |
| [`69a15fda`](https://github.com/NixOS/nixpkgs/commit/69a15fdad1702fff41497699a003fd65c0e4e961) | `` python3Packages.mypy-boto3-connect: 1.42.96 -> 1.43.0 ``                            |
| [`321071e7`](https://github.com/NixOS/nixpkgs/commit/321071e72deb19302ef801d197459724ba84856f) | `` python3Packages.mypy-boto3-config: 1.42.68 -> 1.43.0 ``                             |
| [`908aab48`](https://github.com/NixOS/nixpkgs/commit/908aab4809406d952453ed30ac2c81aa3aac88a1) | `` python3Packages.mypy-boto3-compute-optimizer: 1.42.93 -> 1.43.0 ``                  |
| [`e8150829`](https://github.com/NixOS/nixpkgs/commit/e815082913f25416917a90f1c276a64cb9923363) | `` python3Packages.mypy-boto3-comprehendmedical: 1.42.93 -> 1.43.0 ``                  |
| [`ce6fabec`](https://github.com/NixOS/nixpkgs/commit/ce6fabec8a16f81af05b36c1b8a35be7e7b2ec13) | `` python3Packages.mypy-boto3-comprehend: 1.42.3 -> 1.43.0 ``                          |
| [`25a78b32`](https://github.com/NixOS/nixpkgs/commit/25a78b327e541291a6c25d20414155cd08392edc) | `` python3Packages.mypy-boto3-cognito-sync: 1.42.3 -> 1.43.0 ``                        |
| [`32bf703f`](https://github.com/NixOS/nixpkgs/commit/32bf703f17ba40f3bcb3f31151dcdfbffd4e36df) | `` python3Packages.mypy-boto3-cognito-idp: 1.42.93 -> 1.43.0 ``                        |
| [`944af966`](https://github.com/NixOS/nixpkgs/commit/944af96634c902b47d08b11b01f13b58c7f389ab) | `` python3Packages.mypy-boto3-cognito-identity: 1.42.3 -> 1.43.0 ``                    |
| [`e5b9ab79`](https://github.com/NixOS/nixpkgs/commit/e5b9ab7929d540b1521c203213877af187bb76ee) | `` python3Packages.mypy-boto3-codestar-notifications: 1.42.3 -> 1.43.0 ``              |
| [`11803d0d`](https://github.com/NixOS/nixpkgs/commit/11803d0d7428f4de5b1f28916a7fa67a10a65aca) | `` python3Packages.mypy-boto3-codestar-connections: 1.42.3 -> 1.43.0 ``                |
| [`b9716217`](https://github.com/NixOS/nixpkgs/commit/b97162174f204705ee416c2c63c341fd9331432c) | `` python3Packages.mypy-boto3-codepipeline: 1.42.3 -> 1.43.0 ``                        |
| [`4cf8d030`](https://github.com/NixOS/nixpkgs/commit/4cf8d0302995704d5127b6d3f64c57080ad1f1c4) | `` python3Packages.mypy-boto3-codeguruprofiler: 1.42.3 -> 1.43.0 ``                    |
| [`e75296d4`](https://github.com/NixOS/nixpkgs/commit/e75296d4f9d55be8b9c815341aef573b70ddb132) | `` python3Packages.mypy-boto3-codeguru-security: 1.42.3 -> 1.43.0 ``                   |
| [`4b8347b3`](https://github.com/NixOS/nixpkgs/commit/4b8347b3325f8c4b84a4665aa5044c0fdc735107) | `` python3Packages.mypy-boto3-codeguru-reviewer: 1.42.3 -> 1.43.0 ``                   |
| [`4344a8e5`](https://github.com/NixOS/nixpkgs/commit/4344a8e5bad01c23d4dfc3e98132dc1f08de7425) | `` python3Packages.mypy-boto3-codedeploy: 1.42.3 -> 1.43.0 ``                          |

*... and 1047 more commits (truncated)*