### PR TITLE
chore(flake/nixpkgs): `15f4ee45` -> `549bd84d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -81,11 +81,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777578337,
-        "narHash": "sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM+Z4=",
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                             |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`5c4f3182`](https://github.com/NixOS/nixpkgs/commit/5c4f3182cdb919a5cdf4c4de49ed62d13d63884a) | `` code-cursor: 3.2.11 -> 3.2.21 ``                                                 |
| [`e3187c53`](https://github.com/NixOS/nixpkgs/commit/e3187c5334ecd946dd45b979f7ce9e078800b3e1) | `` json-sort: 1.0.0 -> 1.1.0 ``                                                     |
| [`db6e8bdd`](https://github.com/NixOS/nixpkgs/commit/db6e8bdddfe20a6799a4e6d267ba1c3094b942fe) | `` pgdog: 0.1.38 -> 0.1.39 ``                                                       |
| [`7dcaf76b`](https://github.com/NixOS/nixpkgs/commit/7dcaf76b7ec728da9fef7f84557d4bdf76f34c6a) | `` cwal: 0.8.4 -> 0.8.5 ``                                                          |
| [`9f80ba35`](https://github.com/NixOS/nixpkgs/commit/9f80ba35a0b73fe9844bfa4bfd78627c69a1776f) | `` wml: 2.32.0 -> 2.32.0-unstable-2025-12-23 ``                                     |
| [`3699429b`](https://github.com/NixOS/nixpkgs/commit/3699429b6ba9f735a1dd1e7d09d0c43e4c2fae72) | `` mikmod: 3.2.8 -> 3.2.9 ``                                                        |
| [`e0803930`](https://github.com/NixOS/nixpkgs/commit/e0803930e5fb9e4f3c4f8e33f0531e97eec756b3) | `` nixos/gitea-actions-runner: remove me as maintainer ``                           |
| [`f501d1d4`](https://github.com/NixOS/nixpkgs/commit/f501d1d46247f2b14a93c55a0bd8acc51d952699) | `` sss_code: fix build with Clang/on Darwin ``                                      |
| [`32f58338`](https://github.com/NixOS/nixpkgs/commit/32f583385b1e2f664710d1f37556fa550759e89b) | `` sss_code: fix build on Linux ``                                                  |
| [`8b6c90a3`](https://github.com/NixOS/nixpkgs/commit/8b6c90a31f8ea0f53933bb23d5315cade136d685) | `` python3Packages.pylitterbot: 2025.3.2 -> 2025.4.0 ``                             |
| [`dd3f2603`](https://github.com/NixOS/nixpkgs/commit/dd3f2603556c8984c562aad529f1fe105bd00aae) | `` nixos/nginx: make cipher configuration structured ``                             |
| [`f88aa2d7`](https://github.com/NixOS/nixpkgs/commit/f88aa2d7bf5f6203e7db3b629842532f097f25a3) | `` nixos/tests/postfix-tlspol: fix mta-sts expectation ``                           |
| [`97ca4edd`](https://github.com/NixOS/nixpkgs/commit/97ca4edda71347adcf510d28acf736d6588f3de2) | `` python3Packages.uproot: 5.7.3 -> 5.7.4 ``                                        |
| [`58b06ea5`](https://github.com/NixOS/nixpkgs/commit/58b06ea575b03f82289f3347bacb34cbd08d832e) | `` nixVersions.git: 2.35pre20260503 -> 2.35pre20260504 ``                           |
| [`cf5ed781`](https://github.com/NixOS/nixpkgs/commit/cf5ed7818331f0a19a9f546679b7c6f027e31475) | `` fceux: fix for qt6, update to unstable-2026-04-13, adopt ``                      |
| [`cf92b053`](https://github.com/NixOS/nixpkgs/commit/cf92b053db6c1a31c9119a04bb1ac363908bbd46) | `` maintainers/github-teams.json: Automated sync ``                                 |
| [`0f2c41b3`](https://github.com/NixOS/nixpkgs/commit/0f2c41b37b6b8e6917b11ce1c2da2677f39aeebe) | `` python3Packages.sentry-sdk: 2.58.0 -> 2.59.0 ``                                  |
| [`a218085a`](https://github.com/NixOS/nixpkgs/commit/a218085aa04e68a4834d67a45517c7918d782299) | `` mlvwm: fix build with gcc15 ``                                                   |
| [`69f9b92f`](https://github.com/NixOS/nixpkgs/commit/69f9b92f32cf4def292202fdca113a440fdfcc8b) | `` terraform-providers.tencentcloudstack_tencentcloud: 1.82.89 -> 1.82.91 ``        |
| [`bd7f0aa8`](https://github.com/NixOS/nixpkgs/commit/bd7f0aa80102e938f5a601efa2a7472143e4cb78) | `` uutils-hostname: 0-unstable-2026-04-23 -> 0-unstable-2026-05-04 ``               |
| [`95805051`](https://github.com/NixOS/nixpkgs/commit/95805051b852ce476a6c30e86597e5b7996b0284) | `` uutils-tar: 0-unstable-2026-04-23 -> 0-unstable-2026-05-01 ``                    |
| [`45ea4547`](https://github.com/NixOS/nixpkgs/commit/45ea4547f5f8bb831d94e4fe27f5b724a069aaed) | `` terraform-providers.cloudamqp_cloudamqp: 1.44.4 -> 1.45.2 ``                     |
| [`1e863f91`](https://github.com/NixOS/nixpkgs/commit/1e863f9110b9b603c27fdc6331f025e6061b8568) | `` python3Packages.apify-fingerprint-datapoints: 0.12.0 -> 0.13.0 ``                |
| [`7537cb81`](https://github.com/NixOS/nixpkgs/commit/7537cb81ea0f0e3a6c29e57604574810141bfb6f) | `` gittype: init at 0.10.0 ``                                                       |
| [`a0ee4e7c`](https://github.com/NixOS/nixpkgs/commit/a0ee4e7cc0194e516219a215b7e8f021ef107787) | `` maintainers/github-teams.json: Automated sync ``                                 |
| [`40e84e60`](https://github.com/NixOS/nixpkgs/commit/40e84e60e250fbb2a09b9d54331f59feaf3c6aed) | `` python3Packages.pyexploitdb: 0.3.24 -> 0.3.25 ``                                 |
| [`7137547c`](https://github.com/NixOS/nixpkgs/commit/7137547c00358f86bf6a9ea9e1f846dabaf27206) | `` python3Packages.utitools: mark broken on darwin ``                               |
| [`71c6a806`](https://github.com/NixOS/nixpkgs/commit/71c6a80651ec387e4306dc0bae6c4038ded6f816) | `` python3Packages.wfuzz: add bad3r as maintainer ``                                |
| [`bf61948c`](https://github.com/NixOS/nixpkgs/commit/bf61948c0d0b73bfdfcc20f385bd161b651fcba5) | `` maintainers: add bad3r ``                                                        |
| [`335d81bf`](https://github.com/NixOS/nixpkgs/commit/335d81bf74af25114c97f5d003a466b91e2a84ac) | `` python3Packages.wfuzz: tidy style nits ``                                        |
| [`ba1de2fa`](https://github.com/NixOS/nixpkgs/commit/ba1de2fadb5a557b27d1dbcb6c475779dcece7d0) | `` python3Packages.wfuzz: add netaddr to runtime dependencies ``                    |
| [`c6606136`](https://github.com/NixOS/nixpkgs/commit/c6606136d7d2b7a723eef9148485f3ee0f175c06) | `` python3Packages.wfuzz: fix screenshot plugin on Python 3.13 ``                   |
| [`0135f540`](https://github.com/NixOS/nixpkgs/commit/0135f5402375fbb348f857805f0ceb10f40a6bf5) | `` python3Packages.wfuzz: set meta.mainProgram ``                                   |
| [`9bbb5082`](https://github.com/NixOS/nixpkgs/commit/9bbb5082c11262e137c31fc098a018755093a14a) | `` glooctl: 1.21.3 -> 1.21.4 ``                                                     |
| [`25e22551`](https://github.com/NixOS/nixpkgs/commit/25e2255122e54c17b4319cadae044b988ccc1597) | `` libretro.pcsx2: 0-unstable-2026-02-06 -> 0-unstable-2026-05-01 ``                |
| [`b17c2cfd`](https://github.com/NixOS/nixpkgs/commit/b17c2cfdb3d4e53407cd2c1f92025205800d39f2) | `` nix: bump 2.28.6 -> 2.28.7, 2.30.4 -> 2.30.5, 2.31.4 -> 2.31.5 ``                |
| [`070d5328`](https://github.com/NixOS/nixpkgs/commit/070d5328c8bd9606ab7f483c5bf7eb4c28832241) | `` nix: 2.34.6 -> 2.34.7 ``                                                         |
| [`978725b2`](https://github.com/NixOS/nixpkgs/commit/978725b29ecb9438982f0a6da5617b99c39de7a4) | `` lix_2_94: repair build for mdbook ≥ 0.5 ``                                       |
| [`1fb471c2`](https://github.com/NixOS/nixpkgs/commit/1fb471c2ba198495bdebae219216ca5390f6378e) | `` vscode-extensions.redhat.ansible: 26.4.4 -> 26.4.6 ``                            |
| [`2307b403`](https://github.com/NixOS/nixpkgs/commit/2307b4032c3e6d2b9850d34aeb853cfaa16e6927) | `` various: drop maintainership of some packges ``                                  |
| [`9bde6190`](https://github.com/NixOS/nixpkgs/commit/9bde61907e8e1106b2bfd2594b7eab76bf92a937) | `` azurehound: 2.12.0 -> 2.12.1 ``                                                  |
| [`8b0ed867`](https://github.com/NixOS/nixpkgs/commit/8b0ed867b285efb47661cff8a072c5e9decf0f1e) | `` lunatic: drop ``                                                                 |
| [`fa779238`](https://github.com/NixOS/nixpkgs/commit/fa7792389571a76ed887cac2ff3a4471a527e2f5) | `` chez: 10.3.0 -> 10.4.0 ``                                                        |
| [`3ab827c7`](https://github.com/NixOS/nixpkgs/commit/3ab827c7dc1e82a673beb1a567806f7f39acdc3a) | `` terraform-providers.hetznercloud_hcloud: 1.61.0 -> 1.62.0 ``                     |
| [`4086e123`](https://github.com/NixOS/nixpkgs/commit/4086e1233efe3463396dc1a51ffa5de783c70b81) | `` complgen: 0.9.0 -> 0.9.1 ``                                                      |
| [`0b041aec`](https://github.com/NixOS/nixpkgs/commit/0b041aecaf72808f1f59dda5c0c508ed9d53a1e0) | `` lix_2_95: 2.95.1 -> 2.95.2 ``                                                    |
| [`bb29bae6`](https://github.com/NixOS/nixpkgs/commit/bb29bae64022085d85bd8f0617a61b44ef0f9b74) | `` lix_2_94: 2.94.1 -> 2.94.2 ``                                                    |
| [`93641981`](https://github.com/NixOS/nixpkgs/commit/93641981389101837a6d922eab8535f252d51e0f) | `` dnsproxy: 0.81.2 -> 0.81.3 ``                                                    |
| [`1bce270b`](https://github.com/NixOS/nixpkgs/commit/1bce270b314175e6190de5e63a344c9018ddba4a) | `` terraform-providers.siderolabs_talos: 0.10.1 -> 0.11.0 ``                        |
| [`7c345aec`](https://github.com/NixOS/nixpkgs/commit/7c345aec617366f6577cdec4ce5603baa2fdf443) | `` python3Packages.openfga-sdk: 0.10.2 -> 0.10.3 ``                                 |
| [`45cf5c7c`](https://github.com/NixOS/nixpkgs/commit/45cf5c7c6fac861415afe7318362c98395e5321c) | `` nixos/dae: remove assertion that causes IFD ``                                   |
| [`1eb834a2`](https://github.com/NixOS/nixpkgs/commit/1eb834a2e1cd339522bd294e227db1afcec9b2e7) | `` linuxPackages.nvidia_x11: don't define kernel modules when building libs only `` |
| [`a255338e`](https://github.com/NixOS/nixpkgs/commit/a255338e36c077b5ceb233c9be950b80b92f75d5) | `` koffan: 2.10.0 -> 2.11.0 ``                                                      |
| [`058e80d2`](https://github.com/NixOS/nixpkgs/commit/058e80d2183e5fe170a200e9c7a4151a015d9bca) | `` python3Packages.rchitect: 0.4.9 -> 0.4.10 ``                                     |
| [`289942b7`](https://github.com/NixOS/nixpkgs/commit/289942b71838a8ddb19cc4c133de1a5b7e230b88) | `` wappalyzergo: 0.2.77 -> 0.2.79 ``                                                |
| [`54e4ef4a`](https://github.com/NixOS/nixpkgs/commit/54e4ef4a874a3b6e774d9eddbfd98ae56eb77862) | `` terraform-providers.hashicorp_aws: 6.42.0 -> 6.43.0 ``                           |
| [`1c214bf2`](https://github.com/NixOS/nixpkgs/commit/1c214bf225141cf3c1503db671cdbe4ac77dc11d) | `` gf: Remove 0xd61 as maintainer ``                                                |
| [`05baef15`](https://github.com/NixOS/nixpkgs/commit/05baef15867326f4d6fd12422c46afa184d73195) | `` pocket-tts: 2.0.0 -> 2.1.0 ``                                                    |
| [`b4586fd1`](https://github.com/NixOS/nixpkgs/commit/b4586fd14d1f6664f34e2a3a1597428b3794004e) | `` terraform-providers.integrations_github: 6.12.0 -> 6.12.1 ``                     |
| [`1a1e595c`](https://github.com/NixOS/nixpkgs/commit/1a1e595cc53a9f7c17d629584c3ff00e869e65e9) | `` python3Packages.neo: 0.14.3 -> 0.14.4 ``                                         |
| [`d6d78602`](https://github.com/NixOS/nixpkgs/commit/d6d78602f8ea4e8cf596aa9a237ff0b6e7f013da) | `` diesel-cli: 2.3.8 -> 2.3.9 ``                                                    |
| [`331c7d8e`](https://github.com/NixOS/nixpkgs/commit/331c7d8e3012fcdd2bf76a227e571fcae0656024) | `` pkgs-lib/formats: revert to remarshal for toml ``                                |
| [`ab076fc2`](https://github.com/NixOS/nixpkgs/commit/ab076fc22ddb751249a518de8b3217e1097bcb82) | `` nixos/coredump: migrate to RFC 42-style settings ``                              |
| [`563d020f`](https://github.com/NixOS/nixpkgs/commit/563d020fd4510b180bc046683adb5aae76187c8d) | `` bililiverecorder: Fix changelog URL ``                                           |
| [`baca0d84`](https://github.com/NixOS/nixpkgs/commit/baca0d8479d1ea56040336acdbe7cf29a1c09925) | `` python3Packages.oscpy: drop patch already included in upstream ``                |
| [`c9444c57`](https://github.com/NixOS/nixpkgs/commit/c9444c579b1e10f983f017b80e5f57da824e41ef) | `` just-lsp: 0.4.3 -> 0.4.4 ``                                                      |
| [`b011b9a6`](https://github.com/NixOS/nixpkgs/commit/b011b9a687c8eb7db4feba80c04cf43808bf909c) | `` pulumi-bin: 3.232.0 -> 3.234.0 ``                                                |
| [`3b3656e0`](https://github.com/NixOS/nixpkgs/commit/3b3656e02bb35c56c994c5584c50525de5d94244) | `` python313Packages.google-cloud-firestore: move updateScript to passthru ``       |
| [`1bee13b6`](https://github.com/NixOS/nixpkgs/commit/1bee13b6baf46f6f49bf6814b790bcea275a3361) | `` xosd-xft: move updateScript to passthru ``                                       |
| [`3cca832c`](https://github.com/NixOS/nixpkgs/commit/3cca832ca7166054f7833fbfb92e4a399bbb48b8) | `` syncthing-macos: move updateScript to passthru ``                                |
| [`e2ac4bb6`](https://github.com/NixOS/nixpkgs/commit/e2ac4bb617ac1366b04379066f80a172b796a0c3) | `` sus-compiler: move updateScript to passthru ``                                   |
| [`e40a7abe`](https://github.com/NixOS/nixpkgs/commit/e40a7abeb0b8fb42e3bd72f0a403862ba0837c5d) | `` mlv-app: move updateScript to passthru ``                                        |
| [`7ebc04c0`](https://github.com/NixOS/nixpkgs/commit/7ebc04c082b95522a0250833e9ba1bf8b8aa9eff) | `` mdwatch: move updateScript to passthru ``                                        |
| [`36b8c67c`](https://github.com/NixOS/nixpkgs/commit/36b8c67c84ab7d99633fc42e8da2ee7b4104b5bf) | `` localtunnel: move updateScript to passthru ``                                    |
| [`4cddd527`](https://github.com/NixOS/nixpkgs/commit/4cddd527759697477b665b0f482c633879b23432) | `` kcl: move updateScript to passthru ``                                            |
| [`3efb357c`](https://github.com/NixOS/nixpkgs/commit/3efb357cc1a064ed2010f33cbeba24a3235231d8) | `` gcalcli: move updateScript to passthru ``                                        |
| [`fe448c5d`](https://github.com/NixOS/nixpkgs/commit/fe448c5d14a9681e197b924b164b5288febd432b) | `` crush: move updateScript to passthru ``                                          |
| [`032d9312`](https://github.com/NixOS/nixpkgs/commit/032d9312b2610178a5f6fe681c61c8d1bb297b71) | `` corto: move updateScript to passthru ``                                          |
| [`0a2d1f0e`](https://github.com/NixOS/nixpkgs/commit/0a2d1f0e8bf87dbc1b5de08fa39b5961fec9b596) | `` chirpstack-concentratord: move updateScript to passthru ``                       |
| [`c6e7c284`](https://github.com/NixOS/nixpkgs/commit/c6e7c2844420c35b2ae862299b6f9d11a99cf646) | `` picoscope: use wrapGAppsHook3 instead of manual wrapping ``                      |
| [`59bb1d2f`](https://github.com/NixOS/nixpkgs/commit/59bb1d2f81f4086620be75ea1ffdf65e216d56a3) | `` maintainers: drop sbruder ``                                                     |
| [`838aa439`](https://github.com/NixOS/nixpkgs/commit/838aa43914ce03feb5f3641882df02a265972cd7) | `` cdk8s-cli: 2.206.7 -> 2.206.10 ``                                                |
| [`2d5b1b6b`](https://github.com/NixOS/nixpkgs/commit/2d5b1b6b4d0403df2b9e86cdd01a51febe72fff9) | `` osdlyrics: 0.5.15 -> 0.5.16 ``                                                   |
| [`6fe81a7f`](https://github.com/NixOS/nixpkgs/commit/6fe81a7ff56bd1f78d69a0ea285300ff07a81f5c) | `` python3Packages.bpython: fix build ``                                            |
| [`0251efb9`](https://github.com/NixOS/nixpkgs/commit/0251efb9df705d8d14ea3fec8223b594a6c90952) | `` rpm-ostree: 2024.8 -> 2026.1 ``                                                  |
| [`72e0d2ac`](https://github.com/NixOS/nixpkgs/commit/72e0d2accd36bce0d68ab6427e813a3539ca390b) | `` ocamlPackages.mlbdd: set license ``                                              |
| [`557b6ece`](https://github.com/NixOS/nixpkgs/commit/557b6ece8b230a740e2deaf35444d73210fb0f3c) | `` hof: fix build with Go 1.26 ``                                                   |
| [`cd1a5d74`](https://github.com/NixOS/nixpkgs/commit/cd1a5d74be88b7cf3b872ac0fae14e9377116e88) | `` aube: init at 1.8.0 ``                                                           |
| [`5ab4d406`](https://github.com/NixOS/nixpkgs/commit/5ab4d4069fbd98d16fc27af0191c38cb21c1717e) | `` httperf: drop ``                                                                 |
| [`fa42d089`](https://github.com/NixOS/nixpkgs/commit/fa42d089ab4d4c08099de51303e0c0483e5ce66d) | `` python3Packages.waymax: set license ``                                           |
| [`fa11a784`](https://github.com/NixOS/nixpkgs/commit/fa11a7841cecc8f0c2f96a7024cc48c2b90f0b9c) | `` nixos/dhparams: fix module name typo in warning ``                               |
| [`608dac75`](https://github.com/NixOS/nixpkgs/commit/608dac75891f259cd2b543f441e76936c828b6d4) | `` pretix: 2026.4.0 -> 2026.4.1 ``                                                  |
| [`6726c482`](https://github.com/NixOS/nixpkgs/commit/6726c48251aaea31076ca9e21a7cd633dd94ac33) | `` dyff: 1.11.4 -> 1.12.0 ``                                                        |
| [`e142ebef`](https://github.com/NixOS/nixpkgs/commit/e142ebef75ff2fa6bc42098d75a75b1d8337c69d) | `` nixos/spire: make Workload API socket reachable by non-root workloads ``         |
| [`87e1a570`](https://github.com/NixOS/nixpkgs/commit/87e1a5706b8253bc1b0225b8e91d7e7c045d0c3c) | `` checkip: 0.53.0 -> 0.53.1 ``                                                     |
| [`b7ad48f1`](https://github.com/NixOS/nixpkgs/commit/b7ad48f1cc4f628fb1ba97a5be7c89c4f17abda2) | `` python3Packages.crewai: 1.14.3 -> 1.14.4 ``                                      |
| [`6f2584aa`](https://github.com/NixOS/nixpkgs/commit/6f2584aad6c1ebc741249cae1f7d049aac3336db) | `` python3Packages.mockfs: fix build ``                                             |
| [`847da9ff`](https://github.com/NixOS/nixpkgs/commit/847da9ff1c0da9d4f26f2433dab0b2a75a8dd5e1) | `` python3Packages.fastexcel: 0.20.1 -> 0.20.2 ``                                   |
| [`44b3bd04`](https://github.com/NixOS/nixpkgs/commit/44b3bd041db2cfc850c19ba89f8c49f5a9a92017) | `` panicparse: 2.4.0 -> 2.5.0 ``                                                    |
| [`12d14a2f`](https://github.com/NixOS/nixpkgs/commit/12d14a2f7bd10b4c21b5100d2ac5dd379647b691) | `` python3Packages.raspyrfm-client: set license ``                                  |
| [`8804e499`](https://github.com/NixOS/nixpkgs/commit/8804e49936b90595e5928b6f17e193d80a5ff22f) | `` beanstalkd: fix build with gcc15 ``                                              |
| [`f600b416`](https://github.com/NixOS/nixpkgs/commit/f600b416d1ca7eaa286452f12df4a9e0a2d436f8) | `` python3Packages.iamdata: 0.1.202605021 -> 0.1.202605041 ``                       |
| [`a388f0dd`](https://github.com/NixOS/nixpkgs/commit/a388f0ddbf8e21fe79daad453d79e0dfd8b472a8) | `` python3Packages.python-doi: set license ``                                       |
| [`5799cd2c`](https://github.com/NixOS/nixpkgs/commit/5799cd2c72267eb5851b7df39d76fabfbadb8bbb) | `` lazyworktree: 1.45.0 -> 1.45.1 ``                                                |
| [`65e935d9`](https://github.com/NixOS/nixpkgs/commit/65e935d9317703276c30122929e96860440154d4) | `` python3Packages.deezer-python: migrate to finalAttrs ``                          |
| [`b61e0381`](https://github.com/NixOS/nixpkgs/commit/b61e03817c4ff1d05bc75bbf59d62ee538560982) | `` python3Packages.deezer-python: 7.2.0 -> 7.3.0 ``                                 |
| [`8e282289`](https://github.com/NixOS/nixpkgs/commit/8e28228999f2fe5256ac9793c5f34928320a50e0) | `` nix-update: 1.14.0 -> 1.15.0 ``                                                  |
| [`e0c25219`](https://github.com/NixOS/nixpkgs/commit/e0c2521935136b3453c5489e0d5fdd90f5c048b0) | `` context7-mcp: 2.2.0 -> 2.2.3 ``                                                  |
| [`03f31c67`](https://github.com/NixOS/nixpkgs/commit/03f31c673735a3dea004d7b3a91fd2cced274898) | `` pngoptimizer: fix build with gcc15 ``                                            |
| [`99c94f59`](https://github.com/NixOS/nixpkgs/commit/99c94f59a7eb11fb00e19122dda59325d69dd6bc) | `` {libsForQt5,qt6Packages}.pyotherside: Try to fix qtquicktests on Darwin ``       |
| [`ddfce04d`](https://github.com/NixOS/nixpkgs/commit/ddfce04d9e943cfe86d70c206eb684250cc7ff03) | `` {libsForQt5,qt6Packages}.pyotherside: Set meta.platforms ``                      |
| [`e7a57acd`](https://github.com/NixOS/nixpkgs/commit/e7a57acdb059b93b542af642bc533159641002a9) | `` {libsForQt5,qt6Packages}.pyotherside: Enable tests ``                            |
| [`678d29f4`](https://github.com/NixOS/nixpkgs/commit/678d29f449851bc56a826e2a22ec7c8617aa97b6) | `` qt6Packages.pyotherside: init at 1.6.2 ``                                        |
| [`02bfcdf2`](https://github.com/NixOS/nixpkgs/commit/02bfcdf263a02723a7a93d1f7ddbf22c24965eb6) | `` libsForQt5.pyotherside: Rename from pyotherside ``                               |
| [`9939a35d`](https://github.com/NixOS/nixpkgs/commit/9939a35d13a2e58854ede60dcc46a6a0b612705f) | `` Revert "opencode: 1.14.31 -> 1.14.33" ``                                         |
| [`397f59e7`](https://github.com/NixOS/nixpkgs/commit/397f59e7d076e228e72451417c56ee4cc42138bd) | `` css-variables-language-server: init at 2.8.4 ``                                  |
| [`8a9b7d2d`](https://github.com/NixOS/nixpkgs/commit/8a9b7d2dda175a2de2ad85dcf27c8c8b544fe96e) | `` steelix: 0-unstable-2026-04-16 -> 0-unstable-2026-05-02 ``                       |
| [`b86854dc`](https://github.com/NixOS/nixpkgs/commit/b86854dc6e6a9e0bbaa60cfb9d3c2b882bf2dfc1) | `` maintainers: add aiwao ``                                                        |
| [`97a841d1`](https://github.com/NixOS/nixpkgs/commit/97a841d1bd57440694fcf3b30e7a517d18bc5469) | `` python3Packages.mediawiki-langcodes: 0.2.21 -> 0.2.22 ``                         |
| [`e0121135`](https://github.com/NixOS/nixpkgs/commit/e01211355f6e89c2dcc754b603b03d33fd3b6afa) | `` jpegli: 0-unstable-2026-04-13 -> 0-unstable-2026-04-30 ``                        |
| [`449a1935`](https://github.com/NixOS/nixpkgs/commit/449a1935e020dde1b2735656f4395fed82e63c3e) | `` firefly-iii: 6.6.1 -> 6.6.2 ``                                                   |
| [`e604511a`](https://github.com/NixOS/nixpkgs/commit/e604511aae073560ed541b33c38f205f5b5952f3) | `` python3Packages.peppercorn: set license ``                                       |
| [`6821c758`](https://github.com/NixOS/nixpkgs/commit/6821c758f59aa0453ae186b52334d5898a26d744) | `` lib.licenses: add bsd3Modification ``                                            |
| [`7ff055d3`](https://github.com/NixOS/nixpkgs/commit/7ff055d3f3e99ed606c3ec74a723021664ee188d) | `` typescript-go: 0-unstable-2026-04-24 -> 0-unstable-2026-05-02 ``                 |
| [`84de183f`](https://github.com/NixOS/nixpkgs/commit/84de183f602c26ab99281c24e52bf1067d240e9b) | `` ior: fix `gcc-15` build failure ``                                               |
| [`aa51c252`](https://github.com/NixOS/nixpkgs/commit/aa51c252768ea11b33211dd67a9e5a958ce54106) | `` python3Packages.pbkdf2: set license ``                                           |
| [`7f2c301a`](https://github.com/NixOS/nixpkgs/commit/7f2c301aa8c96a0d38fd646322a534500c1dba37) | `` python3Packages.obfsproxy: set license ``                                        |
| [`0a1ce689`](https://github.com/NixOS/nixpkgs/commit/0a1ce689eab8a4477f7a20266ef2faf7ec081a59) | `` python3Packages.iowait: set license ``                                           |
| [`233be79f`](https://github.com/NixOS/nixpkgs/commit/233be79f808156adf8aac56138f17e859474c50f) | `` python3Package.hypchat: set license ``                                           |
| [`7ebfaf7f`](https://github.com/NixOS/nixpkgs/commit/7ebfaf7ff8fa48a681218aa13ca9ff229cda5f9b) | `` spruce: 1.35.0 -> 1.35.1 ``                                                      |
| [`91dd67f6`](https://github.com/NixOS/nixpkgs/commit/91dd67f6f4220603162e629a7257ef1bfc386d16) | `` tree-sitter-grammars.tree-sitter-swift: 0.7.1 -> 0.7.2 ``                        |
| [`cb3bcd4d`](https://github.com/NixOS/nixpkgs/commit/cb3bcd4dd72c9ef4cd23bba26e8c42070ec78ff1) | `` hors: drop ``                                                                    |
| [`b7105109`](https://github.com/NixOS/nixpkgs/commit/b710510983a0c6d522676d65d34d46a9a45e066a) | `` pyhon3Packages.duet: set license ``                                              |
| [`f13544d2`](https://github.com/NixOS/nixpkgs/commit/f13544d2f3c8b98eb4401e39b9e1f6cf9420719d) | `` phpunit: 13.1.7 -> 13.1.8 ``                                                     |
| [`bd6dfceb`](https://github.com/NixOS/nixpkgs/commit/bd6dfceb790525b34aa10c338fada4f86b36e767) | `` home-assistant-custom-components.solax_modbus: 2026.04.4 -> 2026.04.5 ``         |
| [`9454def1`](https://github.com/NixOS/nixpkgs/commit/9454def1f4d5d8b68f529150fed3c7d08bf5ad72) | `` quickshell: 0.2.1 -> 0.3.0 ``                                                    |
| [`cfe5ce65`](https://github.com/NixOS/nixpkgs/commit/cfe5ce658a97daaf81a9f51097ae5f5181b83171) | `` python3Packages.contexter: set license ``                                        |
| [`48a9b602`](https://github.com/NixOS/nixpkgs/commit/48a9b6027134d4fb402ce3d4dbe634e216bc0f07) | `` python3Packages.chai: set license ``                                             |
| [`d690e8a1`](https://github.com/NixOS/nixpkgs/commit/d690e8a1e66bcf8af5d35b1812f296d552ce29e6) | `` prometheus-postfix-exporter: 0.19.0 -> 0.20.0 ``                                 |
| [`512fff49`](https://github.com/NixOS/nixpkgs/commit/512fff49428a125c6f462bb09d2ef92d654e6103) | `` python3Packages.avro3k: set license ``                                           |
| [`5467414e`](https://github.com/NixOS/nixpkgs/commit/5467414ec631951fde647a16b5129bc89f763618) | `` python3Packages.atomicwrites: set license ``                                     |
| [`79239609`](https://github.com/NixOS/nixpkgs/commit/79239609c76098f3eb95c93e8b905fb119177483) | `` pphack: 0.1.3 -> 0.1.4 ``                                                        |
| [`f500e41e`](https://github.com/NixOS/nixpkgs/commit/f500e41e2268d048bf45b60405a786a6dfecb8aa) | `` gwc: fix link to changelog ``                                                    |
| [`4082bbd5`](https://github.com/NixOS/nixpkgs/commit/4082bbd5089dd11c5ad0cfe9b12dadb4bb64930e) | `` python3Packages.args: set license ``                                             |
| [`82cc9972`](https://github.com/NixOS/nixpkgs/commit/82cc9972cec9714495d808f47202dfd19a351525) | `` encrypted-dns-server: 0.9.19 -> 0.9.20 ``                                        |
| [`b8025a61`](https://github.com/NixOS/nixpkgs/commit/b8025a61dc8d66963a4b3ae755c3b5acefa8a45e) | `` cpptrace: enable libunwind support ``                                            |
| [`211b440d`](https://github.com/NixOS/nixpkgs/commit/211b440d844c5bdce8768f67449b24da241dc4c1) | `` vimPlugins.zig-vim: move back to generated.nix ``                                |
| [`99f46446`](https://github.com/NixOS/nixpkgs/commit/99f46446c1b5074a8b406334be0a9dd152b3dd6a) | `` chessdb: add license ``                                                          |
| [`327a4887`](https://github.com/NixOS/nixpkgs/commit/327a488796bfb92260838366c6b8a31f832cd9b9) | `` home-assistant-custom-components.pirate-weather: 1.8.7 -> 1.8.8 ``               |
| [`3f537bf6`](https://github.com/NixOS/nixpkgs/commit/3f537bf6f8cd7a0db70276467b3baf8f50d84a46) | `` coc-cmake: set license ``                                                        |
| [`e9a77a7c`](https://github.com/NixOS/nixpkgs/commit/e9a77a7cfeee23175726ab6e0b10abf2f5259e57) | `` libwebm: allow static build ``                                                   |
| [`90c1be3e`](https://github.com/NixOS/nixpkgs/commit/90c1be3ee6daf29de9c079da7b2ee2ec4ada60df) | `` bsh: set license ``                                                              |
| [`0295540e`](https://github.com/NixOS/nixpkgs/commit/0295540e2f3df6ac039d9164537b2959808ea795) | `` python3Packages.primer3: fix build ``                                            |
| [`8e893943`](https://github.com/NixOS/nixpkgs/commit/8e89394381bf22221ffbd1b32fd9ed88d1e9b19d) | `` matrix-tuwunel: 1.6.0 -> 1.6.1 ``                                                |
| [`c5da5b7b`](https://github.com/NixOS/nixpkgs/commit/c5da5b7b502a7ae50b6c38c2b673c08623fb0679) | `` lazysql: 0.4.8 -> 0.4.9 ``                                                       |
| [`2d376d9c`](https://github.com/NixOS/nixpkgs/commit/2d376d9cc21518d39684733c7416d4c00f3b6b0d) | `` claude-agent-acp: update upstream ``                                             |
| [`3ef7ec96`](https://github.com/NixOS/nixpkgs/commit/3ef7ec96dbd64bc17691db368b05d4fed8ce3074) | `` claude-agent-acp: add amadejkastelic as maintainer ``                            |
| [`318577fa`](https://github.com/NixOS/nixpkgs/commit/318577fa5892d07f5f0ffab90ce102bcd772b97f) | `` claude-agent-acp: 0.21.0 -> 0.32.0 ``                                            |
| [`c030fec9`](https://github.com/NixOS/nixpkgs/commit/c030fec926b38cf38a7431a7d3bb9fcf005ff9b0) | `` bcompare: 4.4.7.28397 -> 5.2.0.31950 ``                                          |
| [`89b61401`](https://github.com/NixOS/nixpkgs/commit/89b61401a0c425cad45a106b00508faed5ff6d17) | `` infrastructure-agent: 1.74.1 -> 1.74.2 ``                                        |
| [`f86fd3a3`](https://github.com/NixOS/nixpkgs/commit/f86fd3a33dbcfc295c8530fbb41d2b5c129d03f0) | `` all-cabal-hashes: set license ``                                                 |
| [`2495dc1c`](https://github.com/NixOS/nixpkgs/commit/2495dc1c52ef869ec4558c0edd1cb1ad91d31a64) | `` aliases: update minio_legacy_fs throw to recommend alternatives ``               |
| [`35a20a5f`](https://github.com/NixOS/nixpkgs/commit/35a20a5faa9cb8a62357856b3cbf55cf9a6cccb5) | `` python3Packages.ibmiotf: drop ``                                                 |
| [`ed4291e0`](https://github.com/NixOS/nixpkgs/commit/ed4291e052c72a0b726a035c6c37c3e01f647e65) | `` wakatime-cli: 2.7.0 -> 2.11.3 ``                                                 |
| [`07d7411a`](https://github.com/NixOS/nixpkgs/commit/07d7411ae5962e0445076e6bfe2e4960472586b3) | `` gemini-cli-bin: 0.39.1 -> 0.40.1 ``                                              |
| [`fe562eb7`](https://github.com/NixOS/nixpkgs/commit/fe562eb7d35b3a3ef27e4f52171e793753c32bdd) | `` terraform-providers.vancluever_acme: 2.48.0 -> 2.48.1 ``                         |
| [`fd0fb75f`](https://github.com/NixOS/nixpkgs/commit/fd0fb75f64dff3b936359f43dc51a5ddb7e12ae8) | `` librelane: 3.0.2 -> 3.0.3 ``                                                     |
| [`8dbdf4f7`](https://github.com/NixOS/nixpkgs/commit/8dbdf4f772ec2b9a87fcf907e93c6cf2f3c534e4) | `` discordo: 0-unstable-2026-04-23 -> 0-unstable-2026-04-30 ``                      |
| [`c7bbefcc`](https://github.com/NixOS/nixpkgs/commit/c7bbefcc6c00852998dd2e4277ba7d6105f7ace4) | `` stdenv/meta: Propagate nonTeamMaintainers if possible ``                         |
| [`fcf7bb00`](https://github.com/NixOS/nixpkgs/commit/fcf7bb005962f6e5bf7a63783f81ed3bb456303b) | `` python3Packages.svgdigitizer: 0.14.2 -> 0.14.3 ``                                |
| [`35882f5f`](https://github.com/NixOS/nixpkgs/commit/35882f5f8bb95f79666eb368eaa05121166d937d) | `` outline: 1.7.0 -> 1.7.1 ``                                                       |
| [`42c128c8`](https://github.com/NixOS/nixpkgs/commit/42c128c83a5b29cffaea0c3f62fe44bace2c698a) | `` moshi: use system oniguruma ``                                                   |
| [`43bb2222`](https://github.com/NixOS/nixpkgs/commit/43bb2222fc6f2dc697c7995c968c0e13f4fbf054) | `` gf: 0-unstable-2026-04-11 -> 0-unstable-2026-05-03 ``                            |
| [`a440d51e`](https://github.com/NixOS/nixpkgs/commit/a440d51e404045ba464fb23645d1493b17cddde1) | `` parallel-launcher: 9.0.2 -> 9.0.4 ``                                             |
| [`2538a9fc`](https://github.com/NixOS/nixpkgs/commit/2538a9fccb6552407a3412a35f6fe28eb0bad7fc) | `` python3Packages.certipy: migrate to finalAttrs ``                                |
| [`7af0c95a`](https://github.com/NixOS/nixpkgs/commit/7af0c95ad1512aa14d507b7bf026aaa42f9069d1) | `` floorp-bin-unwrapped: 12.12.2 -> 12.13.0 ``                                      |
| [`210d721c`](https://github.com/NixOS/nixpkgs/commit/210d721c29ac21b4d63e220fde50651f7d4f6543) | `` python3Packages.certihound: 0.3.0 -> 0.3.2 ``                                    |
| [`1007e85b`](https://github.com/NixOS/nixpkgs/commit/1007e85b7428a59e2372c3efdf2a798f074be5c0) | `` python3Packages.scrap-engine: 1.5.1 -> 1.5.4 ``                                  |
| [`7fd2d1c6`](https://github.com/NixOS/nixpkgs/commit/7fd2d1c642dcdf8363d00aeaf4720d26cc807359) | `` python3Packages.certipy: 0.2.2 -> 0.2.3 ``                                       |
| [`b39581da`](https://github.com/NixOS/nixpkgs/commit/b39581da47e38c7683de7f12bbac887ecc3d7214) | `` nixVersions.git: 2.35pre20260407 -> 2.35pre20260503 ``                           |
| [`e4f7a5a4`](https://github.com/NixOS/nixpkgs/commit/e4f7a5a4301480a4fc6b40eea71e9150bb9953cf) | `` resholve: override pip's knownVulnerabilities ``                                 |
| [`ddf7adbf`](https://github.com/NixOS/nixpkgs/commit/ddf7adbfe871771e8a37b781410cc6442cfbcabb) | `` nixos/3proxy: add auto in services type ``                                       |
| [`5d1e75e5`](https://github.com/NixOS/nixpkgs/commit/5d1e75e5304485ddb879fa959c32bdb5d1dda178) | `` python3Packages.types-aiobotocore: 3.5.0 -> 3.6.0 ``                             |
| [`08c549b3`](https://github.com/NixOS/nixpkgs/commit/08c549b334fe1998cafbd36cb7f6136a203c95b1) | `` cog: 0.1.9 -> 0.1.11 ``                                                          |
| [`8c8af8c1`](https://github.com/NixOS/nixpkgs/commit/8c8af8c1901bf3f72c2c8f838dd274ff6c96e227) | `` snx-rs: 6.0.1 -> 6.0.4 ``                                                        |
| [`7b08c457`](https://github.com/NixOS/nixpkgs/commit/7b08c4572f97e322d727832ff6b7cf953709d006) | `` musly: fix build with gcc15 ``                                                   |
| [`0dc14b72`](https://github.com/NixOS/nixpkgs/commit/0dc14b72b399da8b40ddbd66f7c98a736d0b559c) | `` llvmPackages_git: 23.0.0-unstable-2026-04-19 -> 23.0.0-unstable-2026-05-03 ``    |
| [`cd1a0115`](https://github.com/NixOS/nixpkgs/commit/cd1a0115f27736f7d196da15e0ddc5ffc539feb3) | `` checkov: 3.2.525 -> 3.2.526 ``                                                   |
| [`e2373008`](https://github.com/NixOS/nixpkgs/commit/e2373008d093eb10079ba3a86ee009f772cf676b) | `` olympus-unwrapped: 26.04.22.01 -> 26.05.03.05 ``                                 |
| [`00676035`](https://github.com/NixOS/nixpkgs/commit/0067603565e666853986ede3305f72d358b8d145) | `` brush: 0.3.0 -> 0.4.0 ``                                                         |
| [`e373c1ef`](https://github.com/NixOS/nixpkgs/commit/e373c1efefca941b17b00807d719906a3b43dc55) | `` dosbox-x: build with OpenGL on Linux ``                                          |
| [`3e70b8ef`](https://github.com/NixOS/nixpkgs/commit/3e70b8efc1b5563352c01c2741c470d26635fbff) | `` python3Packages.linode-metadata: 0.3.4 -> 0.3.5 ``                               |
| [`b3a443cd`](https://github.com/NixOS/nixpkgs/commit/b3a443cd89930a2c864b40f4bb67b6ea28191b53) | `` nixos/coredump: drop `with lib;` ``                                              |
| [`e02f8ca6`](https://github.com/NixOS/nixpkgs/commit/e02f8ca6feaabb871e192af2f4d18d12cd7c9438) | `` kin-openapi: 0.136.0 -> 0.137.0 ``                                               |
| [`b1732ebd`](https://github.com/NixOS/nixpkgs/commit/b1732ebd4e638b52cdbae6af1f30cc9a325a4951) | `` nixos/tetrd: remove CAP_DAC_OVERRIDE ``                                          |
| [`d410a00d`](https://github.com/NixOS/nixpkgs/commit/d410a00db8b96a0c6298294302fdad9ded5480ac) | `` flow: 0.311.0 -> 0.312.0 ``                                                      |
| [`f691dd4f`](https://github.com/NixOS/nixpkgs/commit/f691dd4f18975ba38f99fa3c87a3a964e6ba22cb) | `` trayscale: 0.18.8 -> 0.18.9 ``                                                   |
| [`c9f5329e`](https://github.com/NixOS/nixpkgs/commit/c9f5329eff460729ccc4207e43da3ae9fa42a82d) | `` fosrl-gerbil: 1.3.1 -> 1.4.0 ``                                                  |
| [`bc36575c`](https://github.com/NixOS/nixpkgs/commit/bc36575cd6f471e034cacb812a501900ac637218) | `` qlever: 0.5.46 -> 0.5.47 ``                                                      |
| [`6226afed`](https://github.com/NixOS/nixpkgs/commit/6226afedda7fe1fa2b8909e7a4adce5aeb2a6ba3) | `` telegraf: pass --long-plt to linker on AArch32 ``                                |
| [`b5e85a04`](https://github.com/NixOS/nixpkgs/commit/b5e85a04d9ce8d6517092c55a8255a18438c22ba) | `` sudo-font: fix missing webfont output ``                                         |
| [`69d5c18b`](https://github.com/NixOS/nixpkgs/commit/69d5c18bfa1fce28ccd10067e0806175ad1808f4) | `` stix-two: only install woff from otf source ``                                   |
| [`9df1faea`](https://github.com/NixOS/nixpkgs/commit/9df1faea983a858e8a5e656377cce9aa1a34cdc8) | `` stix-two: fix missing webfont output ``                                          |
| [`fc6b8b8c`](https://github.com/NixOS/nixpkgs/commit/fc6b8b8c0fc27fc69f746e029f3bb95681084942) | `` route159: fix missing webfont output ``                                          |
| [`56e21a10`](https://github.com/NixOS/nixpkgs/commit/56e21a1065a76861441b6859842981d1ad12f44f) | `` mona-sans: fix missing webfont output ``                                         |
| [`50cec1f6`](https://github.com/NixOS/nixpkgs/commit/50cec1f6b14d675ce859182a135eba74b195b2d8) | `` lora: fix missing webfont output ``                                              |
| [`133ef29d`](https://github.com/NixOS/nixpkgs/commit/133ef29db5677a3db8ac8e79116399d5dc7a954d) | `` literata: fix missing webfont output ``                                          |
| [`2b7d7d44`](https://github.com/NixOS/nixpkgs/commit/2b7d7d44f07f349f949270c32b6a53d9e62afce1) | `` linden-hill: fix missing webfont output ``                                       |
| [`def50da1`](https://github.com/NixOS/nixpkgs/commit/def50da1e353d1397341b5d3221a18be250d9b7c) | `` hubot-sans: fix missing webfont output ``                                        |
| [`c03130e9`](https://github.com/NixOS/nixpkgs/commit/c03130e96d6b83268b2d92095a0ad4842e152c7a) | `` git-ls: 5.10.0 -> 6.0.0 ``                                                       |
| [`f09df215`](https://github.com/NixOS/nixpkgs/commit/f09df215ef3572efb8b661d2dad2702052797414) | `` qlever-control: 0.5.46 -> 0.5.47 ``                                              |
| [`7797b9d4`](https://github.com/NixOS/nixpkgs/commit/7797b9d44f476cae450fb039385d89a151104942) | `` python2Packages.pip: mark insecure ``                                            |
| [`d057035c`](https://github.com/NixOS/nixpkgs/commit/d057035c767d725b18d951064896cd96de000e93) | `` vscode-extensions.marp-team.marp-vscode: 3.4.1 -> 3.5.0 ``                       |
| [`17d1ab10`](https://github.com/NixOS/nixpkgs/commit/17d1ab101430bb09108e52a3967de2a3aeb6e0c0) | `` uhk-agent: 9.0.2 -> 10.0.0 ``                                                    |
| [`bf2134f0`](https://github.com/NixOS/nixpkgs/commit/bf2134f07c89d83335fb3ed6eac2d5ed2561aff1) | `` terraform-providers.sumologic_sumologic: 3.2.5 -> 3.2.7 ``                       |
| [`aef71357`](https://github.com/NixOS/nixpkgs/commit/aef71357a9f0be3244c10135c3fd535d76bb4efe) | `` cooper: fix missing webfont output ``                                            |
| [`d4eabd25`](https://github.com/NixOS/nixpkgs/commit/d4eabd2502e4ad86838787c40b3ad9a9d84b86a7) | `` bodoni-moda: fix missing webfont output ``                                       |
| [`62265871`](https://github.com/NixOS/nixpkgs/commit/62265871b137df9fa2d21828ec29b09d651b3557) | `` blackout: fix missing webfont output ``                                          |
| [`da99992a`](https://github.com/NixOS/nixpkgs/commit/da99992a63d4bd1ad9f989f33adf25057572e67f) | `` besley: fix missing webfont output ``                                            |
| [`c7aaaebf`](https://github.com/NixOS/nixpkgs/commit/c7aaaebf2ee256cf027e76836f1872658efc6e7f) | `` behdad-fonts: fix missing webfont output ``                                      |
| [`dca79d20`](https://github.com/NixOS/nixpkgs/commit/dca79d2004e12f3b0e1a5d361312e67ad8e1ec68) | `` beedii: fix missing webfont output ``                                            |
| [`4ba92380`](https://github.com/NixOS/nixpkgs/commit/4ba923802bbebeb663aec0d76c4c38de84d8f6cb) | `` atkinson-hyperlegible-next: fix missing webfont output ``                        |
| [`1994cb16`](https://github.com/NixOS/nixpkgs/commit/1994cb161fdf321fa849b096406a982e95773500) | `` atkinson-hyperlegible-mono: fix missing webfont output ``                        |
| [`7d813c31`](https://github.com/NixOS/nixpkgs/commit/7d813c317d4474fbfb6ef5987df8b2daff658919) | `` aleo-fonts: fix missing webfont output ``                                        |
| [`627f4675`](https://github.com/NixOS/nixpkgs/commit/627f4675ebd3a1e3084c8f0933d9f2c2509cde32) | `` alcarin-tengwar: fix missing webfont output ``                                   |
| [`618a16fd`](https://github.com/NixOS/nixpkgs/commit/618a16fd93c98f976df5ca0a3886b192236edb5b) | `` plasmusic-toolbar: 4.0.0 -> 4.1.0 ``                                             |
| [`5667c181`](https://github.com/NixOS/nixpkgs/commit/5667c181bec7e205a90099ce033ad0b30e9067e3) | `` palemoon-bin: 34.2.0 -> 34.2.2 ``                                                |
| [`3c5279af`](https://github.com/NixOS/nixpkgs/commit/3c5279afdbc48fb0d22e76bdd2881778f3b14a02) | `` postgresqlPackages.pg_graphql: 1.5.12 -> 1.6.0 ``                                |
| [`51b85066`](https://github.com/NixOS/nixpkgs/commit/51b85066863ed52a542e8ff7891d4d78e52e765b) | `` nfft: fix build with gcc15 ``                                                    |
| [`547b4805`](https://github.com/NixOS/nixpkgs/commit/547b48052db67037d2695b1d28e9733c87c9bc7c) | `` bootdev-cli: 1.29.2 -> 1.29.3 ``                                                 |
| [`1bb6e593`](https://github.com/NixOS/nixpkgs/commit/1bb6e593605545e8ab166a2fd23be287c813059e) | `` wlink: 0.1.1 -> 0.1.2 ``                                                         |
| [`2cf77276`](https://github.com/NixOS/nixpkgs/commit/2cf77276ea1adf3c0c307fb19eb28be6577ed7d6) | `` luaPackages: update on 2026-05-03 ``                                             |
| [`bc850149`](https://github.com/NixOS/nixpkgs/commit/bc850149696a714ec9470d135bc5d6b11dd3dfe1) | `` dosbox-x: Add updateScript ``                                                    |
| [`0124424b`](https://github.com/NixOS/nixpkgs/commit/0124424bcf8808e1a5196c6bd2ad73a02764f83c) | `` elmPackages.elm: unpin nodejs ``                                                 |
| [`f332126e`](https://github.com/NixOS/nixpkgs/commit/f332126efae1fcb347f89166239ee1524914b7d9) | `` postmoogle: 0.9.30 -> 0.9.31 ``                                                  |
| [`f7e4a6fb`](https://github.com/NixOS/nixpkgs/commit/f7e4a6fb8684f46230af2b2c7c534940c029c710) | `` open-stage-control: drop ``                                                      |
| [`ac5aba83`](https://github.com/NixOS/nixpkgs/commit/ac5aba8340465725923d38c883f20155e5935dec) | `` ntttcp: fix build with gcc15 ``                                                  |
| [`6065124a`](https://github.com/NixOS/nixpkgs/commit/6065124acecbb4200cccdd9d9349fe41bc87c606) | `` thunderbird-latest-unwrapped: 150.0 -> 150.0.1 ``                                |
| [`1c3e1495`](https://github.com/NixOS/nixpkgs/commit/1c3e1495465d571229801c334e4d6b25a1d1998e) | `` Reapply {ci,workflows}: allow multiple blocking reviews" ``                      |
| [`2134ce40`](https://github.com/NixOS/nixpkgs/commit/2134ce40f1edf0affdd339c280777c1311e18315) | `` numdiff: fix build with gcc15 ``                                                 |
| [`b8191c9f`](https://github.com/NixOS/nixpkgs/commit/b8191c9fd8e8b6ae532b16c0b77b0837d980bca6) | `` go-dnscollector: 2.2.2 -> 2.2.3 ``                                               |
| [`00504dca`](https://github.com/NixOS/nixpkgs/commit/00504dcad06c6f81343a68013bb387a5ad4ff054) | `` xremap: 0.15.2 -> 0.15.5 ``                                                      |
| [`0d5e47ab`](https://github.com/NixOS/nixpkgs/commit/0d5e47ab6b5c45c9c162d85e5c26c579bbbdb7d4) | `` vimPlugins: aliases consistent message format ``                                 |
| [`4d0f32fa`](https://github.com/NixOS/nixpkgs/commit/4d0f32fa81be89a9aa0786f1412767fb868c04f6) | `` aws-vault: 7.10.2 -> 7.10.4 ``                                                   |
| [`f4e432ff`](https://github.com/NixOS/nixpkgs/commit/f4e432ff47eed3f55a1ec7fe599cfe4a48301d48) | `` grafanaPlugins.grafana-exploretraces-app: 2.0.2 -> 2.0.3 ``                      |
| [`b8b52d6c`](https://github.com/NixOS/nixpkgs/commit/b8b52d6c73904738672dbf43b3cec08e4e1ea270) | `` python3Packages.batchspawner: cleanup, fix on darwin ``                          |
| [`e51d5606`](https://github.com/NixOS/nixpkgs/commit/e51d560682670eda28f1a1b72dc53ed29bfb6fec) | `` python3Packages.jupyterhub: 5.4.4 -> 5.4.5 ``                                    |
| [`2f7244b6`](https://github.com/NixOS/nixpkgs/commit/2f7244b65b775ef2324ebc09ee5561a78a25e553) | `` git-spice: 0.26.1 -> 0.28.0 ``                                                   |
| [`be851d67`](https://github.com/NixOS/nixpkgs/commit/be851d670f2192550b46194b34aca86e75cbaf9a) | `` magic-enum: 0.9.7 -> 0.9.8 ``                                                    |
| [`5e842e06`](https://github.com/NixOS/nixpkgs/commit/5e842e061006ee945369cf4b4854f68f85a913f4) | `` vimPlugins: update on 2026-05-03 ``                                              |
| [`edf3474f`](https://github.com/NixOS/nixpkgs/commit/edf3474f773b3cbef6f8e1f1ce5bbc6979cbea7e) | `` vimPlugins.mind-nvim: drop package ``                                            |
| [`dbca1ba9`](https://github.com/NixOS/nixpkgs/commit/dbca1ba99c351bc02c740be4c3ef068adcad1fb1) | `` stevenblack-blocklist: 3.16.76 -> 3.16.78 ``                                     |
| [`2ae17d53`](https://github.com/NixOS/nixpkgs/commit/2ae17d535362a4760b2d41fda7fa1cf7cab46282) | `` mtail: 3.2.26 -> 3.2.48 ``                                                       |
| [`3e5d38a7`](https://github.com/NixOS/nixpkgs/commit/3e5d38a7148ab2ea974d7dc7efa54be6af796dcc) | `` nxpmicro-mfgtools: 1.5.139 -> 1.5.243 ``                                         |
| [`168d6d41`](https://github.com/NixOS/nixpkgs/commit/168d6d41097f82eb2d3b5c8fe4e6e53aca4f51de) | `` spooftooph: fix build with gcc15 ``                                              |
| [`f3d026d8`](https://github.com/NixOS/nixpkgs/commit/f3d026d8b009ac2d720a0a88bfc2c3ad00fd971e) | `` check-jsonschema: 0.37.1 -> 0.37.2 ``                                            |
| [`acd5585a`](https://github.com/NixOS/nixpkgs/commit/acd5585a3ba8481395f5897ba6060af176ef7539) | `` lib.systems.parse: check if cpus are equal first ``                              |
| [`90bd946f`](https://github.com/NixOS/nixpkgs/commit/90bd946f28965d7bbfa3eeb5cf559097189c6a48) | `` libretro.genesis-plus-gx: 0-unstable-2026-04-24 -> 0-unstable-2026-05-01 ``      |
| [`51351c14`](https://github.com/NixOS/nixpkgs/commit/51351c14d3c655470bde51218a17f31073a1434d) | `` grype: 0.111.1 -> 0.112.0 ``                                                     |
| [`0bbe8b41`](https://github.com/NixOS/nixpkgs/commit/0bbe8b41cd1ff15d03df7347e87b05c086600f12) | `` melonds: 1.1-unstable-2026-04-20 -> 1.1-unstable-2026-04-30 ``                   |
| [`0737305c`](https://github.com/NixOS/nixpkgs/commit/0737305c9b1eeeb3e9c41447fd4b5c42cc767217) | `` vimPluginsUpdater: inherit license variables into global scope ``                |
| [`f155de1d`](https://github.com/NixOS/nixpkgs/commit/f155de1df00b31b7aea760504f015fa3b65964a8) | `` pyrefly: 0.62.0 -> 0.63.1 ``                                                     |
| [`ccfb472b`](https://github.com/NixOS/nixpkgs/commit/ccfb472b0dd080197f73fb1a27972cc83adeb822) | `` taler-wallet-core: 1.3.1 -> 1.5.10 ``                                            |
| [`3580fa1a`](https://github.com/NixOS/nixpkgs/commit/3580fa1a7960a7086363b305a1127167a9c47ecd) | `` resholve: adapt to marking of py2 setuptools CVE ``                              |
| [`a91c6671`](https://github.com/NixOS/nixpkgs/commit/a91c66717a4650ec9a2ad79f43c304d162a2322a) | `` otpw: fix build with gcc15 ``                                                    |
| [`3ee0f7be`](https://github.com/NixOS/nixpkgs/commit/3ee0f7be0c7d066e76a9dbbe4bf0ca87d1d68d16) | `` python3Packages.pamela: cleanup, fix darwin compat ``                            |
| [`8b858b79`](https://github.com/NixOS/nixpkgs/commit/8b858b79ec5392c9bc23ababb296550a742b53e5) | `` lxgw-neoxihei: 1.242 -> 1.300 ``                                                 |
| [`6f1472df`](https://github.com/NixOS/nixpkgs/commit/6f1472df72b269e870cf1d4581df5c32a5c87bc1) | `` mopac: 23.2.4 -> 23.2.5 ``                                                       |
| [`0e0d5c84`](https://github.com/NixOS/nixpkgs/commit/0e0d5c8494cf5905a0e1305ac09efae42ee45099) | `` terraform-providers.hashicorp_google-beta: 7.29.0 -> 7.30.0 ``                   |
| [`0a41c8e8`](https://github.com/NixOS/nixpkgs/commit/0a41c8e89d1f7c2c2b75c743056778ca56b0682a) | `` nushellPlugins.semver: 0.11.15 -> 0.11.16 ``                                     |
| [`5b84458f`](https://github.com/NixOS/nixpkgs/commit/5b84458f13b6b0b734e7368841e4bad5f782e853) | `` cargo-tarpaulin: 0.35.2 -> 0.35.4 ``                                             |
| [`d7fa4082`](https://github.com/NixOS/nixpkgs/commit/d7fa4082513619f5d503b38970fe660d60b635e2) | `` dosbox-x: 2026.03.29 -> 2026.05.02 ``                                            |
| [`74146587`](https://github.com/NixOS/nixpkgs/commit/74146587f15774de77772ca5e9035462a67e750c) | `` cargo-zigbuild: 0.22.2 -> 0.22.3 ``                                              |
| [`523a512d`](https://github.com/NixOS/nixpkgs/commit/523a512dccae3eb4317794bfd49615fe6b9ef5ed) | `` python3Packages.glyphslib: 6.13.0 -> 6.13.1 ``                                   |
| [`61f842c6`](https://github.com/NixOS/nixpkgs/commit/61f842c6c0d228c17501cf90386aee9c0b5bf833) | `` walker: 2.16.1 -> 2.16.2 ``                                                      |
| [`b8d521d9`](https://github.com/NixOS/nixpkgs/commit/b8d521d9c8beb1e9e52476a933baf3b63c5e3175) | `` ghdump: 0.1.1 -> 0.1.2 ``                                                        |
| [`b50d8204`](https://github.com/NixOS/nixpkgs/commit/b50d82042a594b20e1f2c385ac48e7c1636bb27e) | `` osmo: fix build with gcc15 ``                                                    |
| [`84768ffa`](https://github.com/NixOS/nixpkgs/commit/84768ffae829b5179b477df8eb6ef730c189c3d3) | `` vscode-extensions.discloud.discloud: 2.28.7 -> 2.29.5 ``                         |
| [`c608debb`](https://github.com/NixOS/nixpkgs/commit/c608debbb6416ad5aab01b702ecb608c838f137a) | `` shrikhand: use installFonts, fetch additional formats ``                         |
| [`767f9367`](https://github.com/NixOS/nixpkgs/commit/767f93672c3e7afb1659f4a70e1dbc80e30046ff) | `` defuddle: 0.17.0 -> 0.18.1 ``                                                    |
| [`7bcf9d83`](https://github.com/NixOS/nixpkgs/commit/7bcf9d83484de2c690534762dd5f6a8f9b0b3475) | `` openvpn-auth-ldap: fix build with gcc15 ``                                       |
| [`02a04f20`](https://github.com/NixOS/nixpkgs/commit/02a04f20b72cd77f7c7b55c4b683fa77f73104eb) | `` doc: clarify minio situation in release notes ``                                 |
| [`e88e9103`](https://github.com/NixOS/nixpkgs/commit/e88e91036f89b0e62bdc6f0d1e3cd60f6cde9356) | `` algol68g: 3.11.3 -> 3.12.0 ``                                                    |
| [`ed6ac892`](https://github.com/NixOS/nixpkgs/commit/ed6ac892df83d27f1cefe15a593c0bc001c5fcda) | `` nix-index-unwrapped: 0.1.9-unstable-2026-04-20 -> 0.1.10 ``                      |
| [`cbd89396`](https://github.com/NixOS/nixpkgs/commit/cbd89396f4331cfb4ffdff213c7394b00c182cd7) | `` nano-syntax-highlighting: 2026.03.14 -> 2026.05.01 ``                            |
| [`352de383`](https://github.com/NixOS/nixpkgs/commit/352de38344eaf7ea89599222fc255e2138121c0c) | `` nixfmt-rs: 0.2.0 -> 0.3.0 ``                                                     |
| [`44b401ab`](https://github.com/NixOS/nixpkgs/commit/44b401abc3e9078e2f4e10065d21dae4bbfadc36) | `` imgproxy: 3.31.2 -> 3.31.3 ``                                                    |
| [`cd2e5a37`](https://github.com/NixOS/nixpkgs/commit/cd2e5a371bce6f240cec8b9a156a923b454014fd) | `` Revert "{ci,workflows}: allow multiple blocking reviews" ``                      |
| [`80ad4908`](https://github.com/NixOS/nixpkgs/commit/80ad490878b5dbe2203a01e74824ddb2182278f1) | `` python3Packages.alexapy: 1.29.20 -> 1.29.21 ``                                   |
| [`ba0be230`](https://github.com/NixOS/nixpkgs/commit/ba0be230d5f3f66fabe9022ff2a11c4c6cc5e3d9) | `` vscode-extensions.ms-python.isort: 2025.0.0 -> 2026.4.0 ``                       |
| [`34c95351`](https://github.com/NixOS/nixpkgs/commit/34c95351dca90f05227da7fb6509a96f8967da0b) | `` apt: 3.2.0 -> 3.3.0 ``                                                           |
| [`2f0d77ac`](https://github.com/NixOS/nixpkgs/commit/2f0d77acb5d37c2172bd29c26d8eaa41ccb38986) | `` python3Packages.bqplot: 0.12.45 -> 0.12.46 ``                                    |
| [`a2dd744f`](https://github.com/NixOS/nixpkgs/commit/a2dd744f5e3770d4ab7df6559eb39e3ffce3b936) | `` terraform-providers.sacloud_sakuracloud: 2.35.0 -> 2.35.1 ``                     |
| [`befeaa72`](https://github.com/NixOS/nixpkgs/commit/befeaa727efbe5c56a50aa60c04bc3db1fe716cb) | `` fdk-aac-encoder: 1.0.6 -> 1.0.7 ``                                               |
| [`4231b0ce`](https://github.com/NixOS/nixpkgs/commit/4231b0cecf71b295e4028667f42f43ded0602c0f) | `` nixos/sunshine: new documentation links ``                                       |
| [`68f1ee29`](https://github.com/NixOS/nixpkgs/commit/68f1ee29d4cafdf93b5dfdc57bc7f98b89c48c32) | `` python3Packages.chatlas: 0.15.2 -> 0.16.0 ``                                     |
| [`3a6b2680`](https://github.com/NixOS/nixpkgs/commit/3a6b2680c458b5e00893dace61df1c7ab4242d3d) | `` vscode-extensions.leanprover.lean4: 0.0.234 -> 0.0.236 ``                        |
| [`35e21d83`](https://github.com/NixOS/nixpkgs/commit/35e21d83031d247fdbc1426faf1ae9ca0e9a92f8) | `` brutespray: 2.6.0 -> 2.6.1 ``                                                    |
| [`9711ace5`](https://github.com/NixOS/nixpkgs/commit/9711ace54523b15f791c4d60c6a4ae4981688088) | `` vaultwarden.webvault: 2026.3.1+0 -> 2026.4.1+0 ``                                |
| [`2e733c9a`](https://github.com/NixOS/nixpkgs/commit/2e733c9abfe237a75b15b38c23042e322918dcd5) | `` vaultwarden: 1.35.8 -> 1.36.0 ``                                                 |
| [`2e9eee6a`](https://github.com/NixOS/nixpkgs/commit/2e9eee6a30292e13d7e7be48a9fdba7061fa62db) | `` cotp: 1.9.9 -> 1.9.10 ``                                                         |
| [`c6673d2e`](https://github.com/NixOS/nixpkgs/commit/c6673d2ef45c78f823589a096e0fe00f764ac0cb) | `` doh-proxy-rust: 0.9.15 -> 0.9.16 ``                                              |
| [`a5a9158c`](https://github.com/NixOS/nixpkgs/commit/a5a9158c5ca329711bd7280b678cf7310bd20e0c) | `` python3Packages.sphinxcontrib-bibtex: fix tests broken by docutils 0.22 ``       |
| [`29bd4475`](https://github.com/NixOS/nixpkgs/commit/29bd4475ae607ac6b3dbe534d5f34c44b038111e) | `` mystmd: 1.3.18 -> 1.8.3 ``                                                       |
| [`d2e22243`](https://github.com/NixOS/nixpkgs/commit/d2e22243954141a6680fc7eb4c631dcec19e2d9f) | `` vimPlugins.run-nvim: init at 2.0.0 ``                                            |
| [`021eba30`](https://github.com/NixOS/nixpkgs/commit/021eba30290e491bbe1c36807da9bc60b2e0781f) | `` python3Packages.pyloadapi: 2.0.0 -> 2.1.0 ``                                     |
| [`9c0878ef`](https://github.com/NixOS/nixpkgs/commit/9c0878efceab645197da67fc094c04c89e58e7f2) | `` pantheon-tweaks: 2.5.1 -> 2.5.2 ``                                               |
| [`6a95c29c`](https://github.com/NixOS/nixpkgs/commit/6a95c29c95ca7a420c0bb99abd39dc73b11513c2) | `` python3Packages.widlparser: 1.4.0 -> 1.5.0 ``                                    |
| [`3e075f43`](https://github.com/NixOS/nixpkgs/commit/3e075f434ab4ab9d63b0cd654c5d83134d00ca43) | `` nixos/lib/nixos-test-script-prepend: fix `log` definition ``                     |
| [`ef7c1bdb`](https://github.com/NixOS/nixpkgs/commit/ef7c1bdbc3fe60b4f99ae8d5411f0cd025f4b28b) | `` havn: 0.3.6 -> 0.3.7 ``                                                          |
| [`d6d32e1a`](https://github.com/NixOS/nixpkgs/commit/d6d32e1a005051e1595412aa9416dcf983e45168) | `` mympd: 25.0.1 -> 25.0.2 ``                                                       |
| [`03e96250`](https://github.com/NixOS/nixpkgs/commit/03e96250ded7d382be3b21d946d0cf4f018be714) | `` dc3dd: fix for `gcc-15` ``                                                       |
| [`416db37d`](https://github.com/NixOS/nixpkgs/commit/416db37dde172793338b9a2b780e089f5fdf8f5b) | `` libkqueue: 2.6.4 -> 2.7.0 ``                                                     |
| [`f1e83d38`](https://github.com/NixOS/nixpkgs/commit/f1e83d38920b3e8885f5fe5b4ed82d2f8bab1145) | `` mcp-gateway: 2.9.1 -> 2.11.0 ``                                                  |
| [`62ad5b9a`](https://github.com/NixOS/nixpkgs/commit/62ad5b9a6b2e7124f6007ee2b536084d33c6f3ed) | `` ustreamer: 6.55 -> 6.56 ``                                                       |
| [`1c3eaed6`](https://github.com/NixOS/nixpkgs/commit/1c3eaed6b1d5d3399ee7a6f6d273011040bd25b3) | `` nixos/profiles/base: add explicit support for ext filesystems ``                 |
| [`d2ee4b56`](https://github.com/NixOS/nixpkgs/commit/d2ee4b566987668a6add5dabaec630fe1c27f5c4) | `` wxmaxima: 26.01.0 -> 26.05.0 ``                                                  |
| [`284bf290`](https://github.com/NixOS/nixpkgs/commit/284bf2907cc9eee0b95806174faf88d59d60b555) | `` smtprelay: 1.13.2 -> 1.13.3 ``                                                   |
| [`16939eba`](https://github.com/NixOS/nixpkgs/commit/16939eba9a911d2c1a07e3bc28f773365ec89382) | `` python3Packages.pyintesishome: modernize ``                                      |
| [`af8a3925`](https://github.com/NixOS/nixpkgs/commit/af8a3925844248b5b033824c36030bfe3a669f76) | `` python3Packages.knx-frontend: 2026.4.22.141111 -> 2026.4.30.60856 ``             |
| [`a585591a`](https://github.com/NixOS/nixpkgs/commit/a585591aa391172ae52fdfa79a7c527c03d6a89b) | `` sqlmap: 1.10.3 -> 1.10.5 ``                                                      |
| [`63e174d9`](https://github.com/NixOS/nixpkgs/commit/63e174d99d3a14bb77d94bec1bb5e9b647651c02) | `` python3Packages.claude-agent-sdk: 0.1.71 -> 0.1.72 ``                            |
| [`b17f9963`](https://github.com/NixOS/nixpkgs/commit/b17f9963c5cf1f40e22f1739d365206ae64eeadd) | `` python3Packages.claude-agent-sdk: 0.1.68 -> 0.1.71 ``                            |
| [`0b29c328`](https://github.com/NixOS/nixpkgs/commit/0b29c3289edeb4730cb4b067edf03361cd8c9654) | `` lib.callPackageWith: check if args are already empty before handling defaults `` |
| [`efd9c79a`](https://github.com/NixOS/nixpkgs/commit/efd9c79a80ce8e4596bd60f72537f2c65a87b6fe) | `` lib.callPackageWith: filter names instead of attributes ``                       |
| [`54cbe35b`](https://github.com/NixOS/nixpkgs/commit/54cbe35bf9b3513d5789c76a9be9a448bed24d2c) | `` lib.callPackageWith: use custom version of filterAttrs ``                        |
| [`caab17b2`](https://github.com/NixOS/nixpkgs/commit/caab17b274c0bf5b1763315132af91a80b106582) | `` lib.callPackageWith: move error message variables out of happy path ``           |
| [`6a07020e`](https://github.com/NixOS/nixpkgs/commit/6a07020e3c1734ff6f069a8f4ff33e6a2a0aefae) | `` lib.overrideDerivation: rewrite to not be utterly ridiculous ``                  |
| [`a72cd26c`](https://github.com/NixOS/nixpkgs/commit/a72cd26ceb15e1f9091a72f3edef41dcf28e3589) | `` lib.makeOverridable: avoid some function calls ``                                |
| [`b5884334`](https://github.com/NixOS/nixpkgs/commit/b58843343280f817c6d797c00b07ebc6422d85bc) | `` python3Packages.requests-cache: fix optional-dependencies ``                     |
| [`4da12f05`](https://github.com/NixOS/nixpkgs/commit/4da12f050a2163b7f5a24c092deb9b8882e07576) | `` stdenv/check-meta: call containsLicenses early with list ``                      |
| [`df268eb4`](https://github.com/NixOS/nixpkgs/commit/df268eb420bcc356de685d8b7901b9ca42e052ad) | `` stdenv/check-meta: move negation outside loop, avoid primop if undefined ``      |
| [`833f05d0`](https://github.com/NixOS/nixpkgs/commit/833f05d0994512c721c035c3874078973a2698f6) | `` lib.systems.elaborate: prevent unnecessary attrset merges ``                     |
| [`a9c0a094`](https://github.com/NixOS/nixpkgs/commit/a9c0a094f7e4a530b4681d654d78c087b9441d52) | `` lib.systems.elaborate: avoid optionalAttrs merge ``                              |
| [`7fcbff80`](https://github.com/NixOS/nixpkgs/commit/7fcbff801da7e94701efd93369f090e025ee85dd) | `` lib.systems.parse: only check condition once ``                                  |
| [`577b4817`](https://github.com/NixOS/nixpkgs/commit/577b48177488b96a25b45a735ce63648cc309d8f) | `` lib.systems.parse: use `builtins.head foo` instead of `elemAt foo 0` ``          |

*... and 807 more commits (truncated)*