### PR TITLE
chore(flake/nixpkgs): `331800de` -> `9ae611a4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -81,11 +81,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780243769,
-        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
+        "lastModified": 1781074563,
+        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
+        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                              |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
| [`bf6ada5d`](https://github.com/NixOS/nixpkgs/commit/bf6ada5d786e8aa4faff128e7e73a4792c2e99fe) | `` Revert "pkgs-lib/formats: Use .attrs.json where possible" ``                                                      |
| [`3ee31dd4`](https://github.com/NixOS/nixpkgs/commit/3ee31dd40cd45db6ddc5cf6bd7763c344c4424cc) | `` tfswitch: 1.18.0 -> 1.19.0 ``                                                                                     |
| [`8fdae5e0`](https://github.com/NixOS/nixpkgs/commit/8fdae5e0c03475b039056b609764033b1c0cd5ae) | `` pi-coding-agent: 0.78.0 -> 0.79.1 ``                                                                              |
| [`b92f00f1`](https://github.com/NixOS/nixpkgs/commit/b92f00f1aa2dd915f568c63ad3474e1998b0741d) | `` neowall: 0.4.7 -> 0.5.0 ``                                                                                        |
| [`d71cc463`](https://github.com/NixOS/nixpkgs/commit/d71cc463cc184b82baec685e9df46afd31ae4eb8) | `` databricks-cli: 1.1.0 -> 1.2.1 ``                                                                                 |
| [`abf2b51f`](https://github.com/NixOS/nixpkgs/commit/abf2b51f9348817dbd33e25086cbf698a0c20122) | `` rclip: 3.0.10 -> 3.2.1 ``                                                                                         |
| [`451f9f55`](https://github.com/NixOS/nixpkgs/commit/451f9f558e8a83f4c7194fb94384d62bc05fc40f) | `` bttf: adjust meta.description ``                                                                                  |
| [`851cbf9e`](https://github.com/NixOS/nixpkgs/commit/851cbf9e1e9a5998726145c2f6814e359a777c1c) | `` rmfakecloud: use pnpm 11 ``                                                                                       |
| [`1c7f0fab`](https://github.com/NixOS/nixpkgs/commit/1c7f0fab6606764b3e4a957ae60d5f43e657ff27) | `` rmfakecloud: 0.0.29 -> 0.0.31 ``                                                                                  |
| [`c2091645`](https://github.com/NixOS/nixpkgs/commit/c209164583faa8ae728d663e03a8fdc5d305cce9) | `` msgpack-c: 7.0.0 -> 7.0.1 ``                                                                                      |
| [`3342fa2e`](https://github.com/NixOS/nixpkgs/commit/3342fa2e8f22e98d2d6f01673f41469f10316ce1) | `` zigbee2mqtt: 2.11.0 -> 2.12.0 ``                                                                                  |
| [`c88305b4`](https://github.com/NixOS/nixpkgs/commit/c88305b485fb2423753fa9fadf44b6d2bb495494) | `` localsend: set meta.donationPage ``                                                                               |
| [`ebc7fc9d`](https://github.com/NixOS/nixpkgs/commit/ebc7fc9d0fbc867595b228795627c12f11e85573) | `` gtk-server: use https in links in meta ``                                                                         |
| [`e7e8d4f7`](https://github.com/NixOS/nixpkgs/commit/e7e8d4f799e4bf1764cabc4446a1d6f99301b0ef) | `` bobgen: 0.42.0 -> 0.45.0 ``                                                                                       |
| [`23461d1d`](https://github.com/NixOS/nixpkgs/commit/23461d1d14315e2494b1aa9e2bd4c7147a1fc9ae) | `` terraform-providers.jianyuan_sentry: 0.14.13 -> 0.15.1 ``                                                         |
| [`47f2f253`](https://github.com/NixOS/nixpkgs/commit/47f2f25308df6e3167b0a405f0a123b6b5dd510b) | `` kazumi: 2.1.3 -> 2.1.4 ``                                                                                         |
| [`174d70e2`](https://github.com/NixOS/nixpkgs/commit/174d70e22bc58071d843bcad86ae284227713972) | `` python3Packages.openvino-genai: init at 2026.2.0.0 ``                                                             |
| [`5bc6eb63`](https://github.com/NixOS/nixpkgs/commit/5bc6eb63e6f52974b91a10ae0d533d18b7257692) | `` openvino-genai: init at 2026.2.0.0 ``                                                                             |
| [`6924c43f`](https://github.com/NixOS/nixpkgs/commit/6924c43ffc2782e30cca0c6d18f202e10c965a62) | `` python3Packages.openvino-tokenizers: init at 2026.2.0.0 ``                                                        |
| [`340a0a7e`](https://github.com/NixOS/nixpkgs/commit/340a0a7ed62a0b4046cf4461818c2968860de90c) | `` openvino-tokenizers: init at 2026.2.0.0 ``                                                                        |
| [`d83549d3`](https://github.com/NixOS/nixpkgs/commit/d83549d3fd145cf240f1b1ed325ef6e96028e702) | `` openvino: fix install layout with OV_CPACK_* variables ``                                                         |
| [`ae8af575`](https://github.com/NixOS/nixpkgs/commit/ae8af575ed875d8a934e78016655d0a7094283b5) | `` python3Packages.sentry-sdk: fix tests on Python 3.13 darwin | refactor ``                                         |
| [`c37d6043`](https://github.com/NixOS/nixpkgs/commit/c37d6043347f41af801398075397ebf7aaadb9ed) | `` sif: 0-unstable-2026-04-24 -> 0-unstable-2026-06-09 ``                                                            |
| [`4eafbbd1`](https://github.com/NixOS/nixpkgs/commit/4eafbbd1c52a405c502611aa5c870a4c98456088) | `` sandhole: 0.9.5 -> 0.10.0 ``                                                                                      |
| [`1edf3900`](https://github.com/NixOS/nixpkgs/commit/1edf3900ab51e800026c66b975a32cd970c0a605) | `` python3Packages.langchain-ollama: migrate to finalAttrs, structuredAttrs, and strictDeps ``                       |
| [`1bafba24`](https://github.com/NixOS/nixpkgs/commit/1bafba24a4a79c75b40508f7caad590c229c3fa3) | `` python3Packages.langchain-ollama: remove dependency relaxation on langchain-core ``                               |
| [`6702699a`](https://github.com/NixOS/nixpkgs/commit/6702699abd89d1ba5139dd9c0af44cb0607f1eb1) | `` python3Packages.langchain-ollama: update check inputs ``                                                          |
| [`184ee7c0`](https://github.com/NixOS/nixpkgs/commit/184ee7c0e55adabf2e66c570b23575139412c315) | `` typesetter: 0.13.3 -> 0.13.5 ``                                                                                   |
| [`ee4b85ee`](https://github.com/NixOS/nixpkgs/commit/ee4b85eeb44a9e95e98a2913bb970903decdc4ed) | `` python3Packages.cvxpy: relax sparsediffpy ``                                                                      |
| [`f1a3c2f1`](https://github.com/NixOS/nixpkgs/commit/f1a3c2f1846630f3e41c4e201113b1c111c23dbc) | `` python3Packages.sparsediffpy: 0.3.0 -> 0.4.0 ``                                                                   |
| [`a5342aec`](https://github.com/NixOS/nixpkgs/commit/a5342aecb6a303bc04fc0d9f1f66da550ef10e36) | `` python3Packages.atopile: disable more tests prone to time out ``                                                  |
| [`49dce292`](https://github.com/NixOS/nixpkgs/commit/49dce29261391363f7de456a76b0fb0e7ba83598) | `` google-chrome: 149.0.7827.53 -> 149.0.7827.102 ``                                                                 |
| [`93a201c4`](https://github.com/NixOS/nixpkgs/commit/93a201c4b609e7570b045a866291b7fbff4910c4) | `` barracuda: init at 0.5 ``                                                                                         |
| [`ea789603`](https://github.com/NixOS/nixpkgs/commit/ea789603512c678abe16b47f9ef9f9ad8aba1896) | `` home-assistant-custom-components.garmin_connect: ignore ha-garmin version requirement ``                          |
| [`ff7405a8`](https://github.com/NixOS/nixpkgs/commit/ff7405a8d832f0b54666640f1bc5128c073f110b) | `` apfel-llm: add arthurficial as maintainer ``                                                                      |
| [`918652a9`](https://github.com/NixOS/nixpkgs/commit/918652a9ab38eada36e8731bd1a689bb3770382b) | `` maintainers: add arthurficial ``                                                                                  |
| [`5276346d`](https://github.com/NixOS/nixpkgs/commit/5276346d8bf251d790a89fd5f3a679dba6703dca) | `` hyprlax: 2.2.2 -> 2.2.4 ``                                                                                        |
| [`41b71e87`](https://github.com/NixOS/nixpkgs/commit/41b71e879a5700459288b96117016c9bea31a516) | `` termscp: 1.0.0 -> 1.1.1 ``                                                                                        |
| [`624be244`](https://github.com/NixOS/nixpkgs/commit/624be244f788d1ae604838c465be8ba53ed5f313) | `` python3Packages.cyclopts: 4.16.1 -> 4.17.0 ``                                                                     |
| [`5b742fe8`](https://github.com/NixOS/nixpkgs/commit/5b742fe85a61f757b3771fee4c653598f779340f) | `` bird3: 3.3.0 -> 3.3.1 ``                                                                                          |
| [`701c782f`](https://github.com/NixOS/nixpkgs/commit/701c782f72ee08781964bd771e3fe7be839df7f3) | `` bird2: 2.19.0 -> 2.19.1 ``                                                                                        |
| [`895b0b78`](https://github.com/NixOS/nixpkgs/commit/895b0b78999f782e8588c70493df438c93522873) | `` libdeltachat: 2.51.0 -> 2.52.0 ``                                                                                 |
| [`aeaabce7`](https://github.com/NixOS/nixpkgs/commit/aeaabce790c1219d1a28cbb7ed20212bd28adc19) | `` onionshare: 2.6.3 -> 2.6.4 ``                                                                                     |
| [`8d4b3960`](https://github.com/NixOS/nixpkgs/commit/8d4b3960f7447ead0070abfdb8d7af1ff41a584a) | `` python3Packages.awkward: 2.9.0 -> 2.9.1 ``                                                                        |
| [`07f108b8`](https://github.com/NixOS/nixpkgs/commit/07f108b8c1d2dc5837b9d485a79ea7cd288049a6) | `` python3Packages.awkward-cpp: 52 -> 53 ``                                                                          |
| [`d6dc50cd`](https://github.com/NixOS/nixpkgs/commit/d6dc50cd59e372efecd3f4a6cf7aed59883ce2d8) | `` cc-token: init at unstable-2025-12-04 ``                                                                          |
| [`10ea2a71`](https://github.com/NixOS/nixpkgs/commit/10ea2a71e20c9aea08c2e2c332a0eabcdf3d8c75) | `` jasterix: init at 0.1.4 ``                                                                                        |
| [`0b5777bf`](https://github.com/NixOS/nixpkgs/commit/0b5777bfcbd93b5d162406277499547a46daff66) | `` newsflash: add missing glycin dependencies ``                                                                     |
| [`ca126187`](https://github.com/NixOS/nixpkgs/commit/ca12618780dc2dae9b977589796545fc86092352) | `` vicinae: 0.21.3 -> 0.21.6 ``                                                                                      |
| [`5424cbec`](https://github.com/NixOS/nixpkgs/commit/5424cbecfe371dcd7f2704cb4ee1787ac7200107) | `` uv: 0.11.17 -> 0.11.19 ``                                                                                         |
| [`4347f5d5`](https://github.com/NixOS/nixpkgs/commit/4347f5d54b9bc16dffbfd79218ed3b0ec77ec9a7) | `` python3Packages.pyg-lib: init at 0.7.0 ``                                                                         |
| [`1591fcdd`](https://github.com/NixOS/nixpkgs/commit/1591fcddab710d94ba41d81f7eb2b968df342b6d) | `` moonfire-nvr: add update script ``                                                                                |
| [`596c89a9`](https://github.com/NixOS/nixpkgs/commit/596c89a917db556bc50b06fc088a36d3dd197343) | `` moonfire-nvr: 0.7.20 -> 0.7.31 ``                                                                                 |
| [`771def51`](https://github.com/NixOS/nixpkgs/commit/771def51e5384f5dd107a58e8316e637460a3b86) | `` linux_xanmod_latest: 7.0.11 -> 7.0.12 ``                                                                          |
| [`c77f429a`](https://github.com/NixOS/nixpkgs/commit/c77f429a2567b857b71077c4b62f612a139d78b1) | `` linux_xanmod: 6.18.34 -> 6.18.35 ``                                                                               |
| [`5900fe6c`](https://github.com/NixOS/nixpkgs/commit/5900fe6cf8eca7dc124309029a50c7f80e90b6c9) | `` claude-code: 2.1.161 -> 2.1.170 ``                                                                                |
| [`beeb8159`](https://github.com/NixOS/nixpkgs/commit/beeb8159dc4f4750262ef52cd25af08cc9c86cb2) | `` beamPackages.elixir-ls: 0.30.0 -> 0.31.0 ``                                                                       |
| [`a7f9dea7`](https://github.com/NixOS/nixpkgs/commit/a7f9dea772254ef9dd45873aa9f89ff22778f727) | `` python3Packages.aprslib: fix misleading comment ``                                                                |
| [`63513b0a`](https://github.com/NixOS/nixpkgs/commit/63513b0a34f29603d6502684f49462e86c5868c4) | `` beamPackages.elixir_1_20: 1.20.0 -> 1.20.1 ``                                                                     |
| [`4a1054fc`](https://github.com/NixOS/nixpkgs/commit/4a1054fc6eb9800a680d5aa01e7b886a4f047d63) | `` python3Packages.boost-histogram: disable crashing tests on darwin ``                                              |
| [`a8f8c0ed`](https://github.com/NixOS/nixpkgs/commit/a8f8c0ed8623532e839a260b6959033b629223cd) | `` warp-terminal: fix darwin build ``                                                                                |
| [`a552f494`](https://github.com/NixOS/nixpkgs/commit/a552f494b9da0111983de9aa2185678e2bf223b3) | `` fcitx5-lua: switch to finalAttrs, hardcode pname, move lua5_3 out of top-level ``                                 |
| [`8c9434be`](https://github.com/NixOS/nixpkgs/commit/8c9434beea65d216ac05852f17c62626ad1c0e27) | `` cppcheck: 2.18.3 -> 2.21.0 ``                                                                                     |
| [`e42a1fcc`](https://github.com/NixOS/nixpkgs/commit/e42a1fcc6ce14e76e13d4aef3d082e5f67003bd5) | `` ayatana-indicator-display: Fix for cppcheck 2.21.0 ``                                                             |
| [`dc78fa6b`](https://github.com/NixOS/nixpkgs/commit/dc78fa6bb739f3688b67cc738d10b076446188ee) | `` python3Packages.asyncua: modernize ``                                                                             |
| [`02ce558d`](https://github.com/NixOS/nixpkgs/commit/02ce558dab3d125c473be702d86c3cf46ead66b1) | `` python3Packages.asyncua: 1.1.8 -> 2.0 ``                                                                          |
| [`9af850c2`](https://github.com/NixOS/nixpkgs/commit/9af850c21dfaf9c3e26e3f1d65eb0ee8a124b3b6) | `` fuse-overlayfs: 1.16 -> 1.17 ``                                                                                   |
| [`974e2cf0`](https://github.com/NixOS/nixpkgs/commit/974e2cf0a58a7e4b828b88692b925d621cd715c7) | `` pizauth: 1.0.11 -> 1.1.0 ``                                                                                       |
| [`49091d78`](https://github.com/NixOS/nixpkgs/commit/49091d78a4df7a536c4aa0f385f7481833999db6) | `` pizauth: fix systemd units substitutions ``                                                                       |
| [`b3bd938d`](https://github.com/NixOS/nixpkgs/commit/b3bd938d3d5b014efc99844826cb779babdf8d9d) | `` linuxPackages.vhba: migrate kernel module to by-name ``                                                           |
| [`eede6b79`](https://github.com/NixOS/nixpkgs/commit/eede6b7946e6502343150664307a72b8520f27aa) | `` linuxPackages.vhba: add updateScript ``                                                                           |
| [`a156cab3`](https://github.com/NixOS/nixpkgs/commit/a156cab325bea0dfd51321aab1de2126b9d75efc) | `` cdemu-*: update to latest versions ``                                                                             |
| [`a9aa8b41`](https://github.com/NixOS/nixpkgs/commit/a9aa8b41038423efa2805a0d5507cf5d915e7b34) | `` cdemu-*: add updateScript ``                                                                                      |
| [`9d366f5d`](https://github.com/NixOS/nixpkgs/commit/9d366f5d08344c21fa2e847f031fe9b79f88c165) | `` cdemu-*: migrate to by-name ``                                                                                    |
| [`aa1a4a41`](https://github.com/NixOS/nixpkgs/commit/aa1a4a413eecb93daee0e192e73568499af9d0aa) | `` cdemu: inline common-drv-attrs and refactor ``                                                                    |
| [`c76ef019`](https://github.com/NixOS/nixpkgs/commit/c76ef019d93caaa320ba6d9b25fe1b2a8ce3faca) | `` anyrun: 25.12.0 -> 26.6.1 ``                                                                                      |
| [`df90e277`](https://github.com/NixOS/nixpkgs/commit/df90e277311d05257e04bc79d03f0112221a0b30) | `` hyprshell: 4.10.6 -> 4.10.7 ``                                                                                    |
| [`819f1a80`](https://github.com/NixOS/nixpkgs/commit/819f1a801cd56f8a8b711195a581c250dfa12616) | `` tor{-browser}: set meta.donationPage ``                                                                           |
| [`c5059c32`](https://github.com/NixOS/nixpkgs/commit/c5059c32b6c014e9d03c12121768942f2641af28) | `` taler-wallet-core: update pnpm & fetcher versions ``                                                              |
| [`7a813a41`](https://github.com/NixOS/nixpkgs/commit/7a813a41db73f481a2f63851effa5204c579028f) | `` radicle-desktop: 0.11.0 -> 0.12.0 ``                                                                              |
| [`f5fc776c`](https://github.com/NixOS/nixpkgs/commit/f5fc776cc48c3920500f47758a1cb5cd3140c62d) | `` kubernetes-helm: 3.20.2 -> 4.2.0 ``                                                                               |
| [`d885f2e0`](https://github.com/NixOS/nixpkgs/commit/d885f2e092bbd0cf5f40c458973bcd6892a09afd) | `` vimPlugins.sqlite-lua: skip bookmarks example check ``                                                            |
| [`75133828`](https://github.com/NixOS/nixpkgs/commit/75133828a2f9d442a25598c997aeb452ddb81c30) | `` rclone: 1.74.2 -> 1.74.3 ``                                                                                       |
| [`cd63cf95`](https://github.com/NixOS/nixpkgs/commit/cd63cf95627c9c0e602d8dd31a48439952c76aa5) | `` mpy-utils: drop fusepy, modernize derivation and unbreak on darwin ``                                             |
| [`8b0c0e7a`](https://github.com/NixOS/nixpkgs/commit/8b0c0e7afe0daa2eb3505ccf62a48a301eacb50c) | `` losange: init at 0.10.1 ``                                                                                        |
| [`e91e36f9`](https://github.com/NixOS/nixpkgs/commit/e91e36f9f2e60ea2f059a37a771b8319b2ace958) | `` rquickshare: pin pnpm to v10 ``                                                                                   |
| [`cc302009`](https://github.com/NixOS/nixpkgs/commit/cc3020092912d763c2dd248845eb294a5fc75be4) | `` python3Packages.django-vcache: 2.1.1 -> 2.2.0 ``                                                                  |
| [`d272ee5c`](https://github.com/NixOS/nixpkgs/commit/d272ee5c8d00ea0f308feadff3f6ad7c6e7732c3) | `` flood: pnpm_9 -> pnpm_10 ``                                                                                       |
| [`e4875cd8`](https://github.com/NixOS/nixpkgs/commit/e4875cd8407d8a79226f8ad0e0b2bcbee999bf51) | `` watchlog: 1.259.0 -> 1.261.0 ``                                                                                   |
| [`87450e1f`](https://github.com/NixOS/nixpkgs/commit/87450e1f172d539844f01a2f0b16296d7e7fab0e) | `` anytype: automatically update bun node_modules ``                                                                 |
| [`ce183ddc`](https://github.com/NixOS/nixpkgs/commit/ce183ddcc5a701ec5bf9684b1b425e5e2083eed5) | `` python3Packages.meshtastic: 2.7.8 -> 2.7.9 ``                                                                     |
| [`b6d7e752`](https://github.com/NixOS/nixpkgs/commit/b6d7e7527869ef45a3eceaa2f6be535a57fe4658) | `` flightgear: 2024.1.6-rc1 -> 2024.1.6 ``                                                                           |
| [`fa68998f`](https://github.com/NixOS/nixpkgs/commit/fa68998f32d03f1aebd9c77f09e77cee1e8e2c57) | `` python3Packages.nomadnet: add `drupol` as maintainer ``                                                           |
| [`e4f3cd6c`](https://github.com/NixOS/nixpkgs/commit/e4f3cd6cc3e78b1d173f5f5a4b4498308bb30903) | `` python3Packages.rns: add `drupol` as maintainer ``                                                                |
| [`93103b56`](https://github.com/NixOS/nixpkgs/commit/93103b5685d116c657e88a0d21b7222822ce42a3) | `` python3Packages.lxmf: add `drupol` as maintainer ``                                                               |
| [`d12a199d`](https://github.com/NixOS/nixpkgs/commit/d12a199dc27e75c61798bce8c70a8cb907c58f06) | `` pretix: 2026.5.0 -> 2026.5.1 ``                                                                                   |
| [`5663fd37`](https://github.com/NixOS/nixpkgs/commit/5663fd3709be4482282358a237d640efb7510110) | `` python3Packages.bluezero: init at 0.9.1 ``                                                                        |
| [`52f71918`](https://github.com/NixOS/nixpkgs/commit/52f7191837711de40d8ebe4de850cfcaad238e3f) | `` pocketbase: 0.39.0 -> 0.39.3 ``                                                                                   |
| [`f8c609f2`](https://github.com/NixOS/nixpkgs/commit/f8c609f2886911874a030330786313ed71dce36d) | `` shellhub-agent: 0.24.2 -> 0.25.0 ``                                                                               |
| [`443107ae`](https://github.com/NixOS/nixpkgs/commit/443107aefbd242c47a58c5941c9cff4e9a407e98) | `` chromium,chromedriver: 149.0.7827.53 -> 149.0.7827.102 ``                                                         |
| [`604b1b06`](https://github.com/NixOS/nixpkgs/commit/604b1b069d783bb4a64ede971a0e6df6a9174b2a) | `` sdl_gamecontrollerdb: 0-unstable-2026-05-28 -> 0-unstable-2026-06-07 ``                                           |
| [`aae769fe`](https://github.com/NixOS/nixpkgs/commit/aae769fe309cdcea5792003c609926a038610359) | `` river: set meta.donationPage ``                                                                                   |
| [`3e35220f`](https://github.com/NixOS/nixpkgs/commit/3e35220fc8b63979384b833b85f157c32e7f9787) | `` ghostty: set meta.donationPage ``                                                                                 |
| [`0088fcde`](https://github.com/NixOS/nixpkgs/commit/0088fcded687d698e958628a979f93914ad65944) | `` linux_6_12: 6.12.92 -> 6.12.93 ``                                                                                 |
| [`4e8d7d74`](https://github.com/NixOS/nixpkgs/commit/4e8d7d7406b6870487a607098edf53714a31773f) | `` linux_6_18: 6.18.34 -> 6.18.35 ``                                                                                 |
| [`a5333921`](https://github.com/NixOS/nixpkgs/commit/a53339212cd0c317b9d2281ad7b54d45d2cdbdd6) | `` linux_7_0: 7.0.11 -> 7.0.12 ``                                                                                    |
| [`b027095b`](https://github.com/NixOS/nixpkgs/commit/b027095b14fc863104b8c9d2a5440a44fe087d84) | `` linux_testing: 7.1-rc6 -> 7.1-rc7 ``                                                                              |
| [`1c20931a`](https://github.com/NixOS/nixpkgs/commit/1c20931a2b2b3c4096bb0fe6d8427aeb8102632d) | `` v2ray-domain-list-community: 20260531040030 -> 20260609060640 ``                                                  |
| [`d0aef1b2`](https://github.com/NixOS/nixpkgs/commit/d0aef1b2309a60eafc72b38da727fabe330c4c4a) | `` frida-tools: add eyjhb as maintainer ``                                                                           |
| [`67c59757`](https://github.com/NixOS/nixpkgs/commit/67c59757800be99e4170266ba24bfff56c8290f3) | `` firefox-bin-unwrapped: 151.0.3 -> 151.0.4 ``                                                                      |
| [`2b00300f`](https://github.com/NixOS/nixpkgs/commit/2b00300f14a7138f06f4dd3d8995f23c518f1879) | `` firefox-unwrapped: 151.0.3 -> 151.0.4 ``                                                                          |
| [`fe199a45`](https://github.com/NixOS/nixpkgs/commit/fe199a45b4eaad11b8326d6b273634640ffb79e7) | `` datafusion-cli: 53.1.0 -> 54.0.0 ``                                                                               |
| [`a9e2ef30`](https://github.com/NixOS/nixpkgs/commit/a9e2ef301c6bb4913f80d1948add4f87af753a6e) | `` hcxtools: modernize ``                                                                                            |
| [`ea541685`](https://github.com/NixOS/nixpkgs/commit/ea541685e86fd4ac462f4c114d323f1370354c0d) | `` musescore: make it find ffmpeg automatically (video export) ``                                                    |
| [`b5e9cca1`](https://github.com/NixOS/nixpkgs/commit/b5e9cca1667666e70abf6814c62dc0b1c759d7b1) | `` git-bug: fix fish completions ``                                                                                  |
| [`490d1c83`](https://github.com/NixOS/nixpkgs/commit/490d1c83c940af710aa2c966e2e43654dae0414d) | `` adscan: init at 9.1.0 ``                                                                                          |
| [`10460c59`](https://github.com/NixOS/nixpkgs/commit/10460c59cba454e8ed05e6d96146018edb158598) | `` python3Packages.credsweeper: init at 1.16.0 ``                                                                    |
| [`fcbcfa55`](https://github.com/NixOS/nixpkgs/commit/fcbcfa55dd1a63fa7bd99eda272080ef9585638d) | `` neovim-unwrapped: apply CVE-2026-11487.patch ``                                                                   |
| [`84e07753`](https://github.com/NixOS/nixpkgs/commit/84e07753d3d564ea064b6544aa7a310cdf508921) | `` python3Packages.django-money: 3.6.0 -> 3.6.1 ``                                                                   |
| [`5e1c3a97`](https://github.com/NixOS/nixpkgs/commit/5e1c3a97aa74ca8812ee468ba474d77907780a84) | `` python3Packages.lxmf: remove `rns` constraint ``                                                                  |
| [`5502fac4`](https://github.com/NixOS/nixpkgs/commit/5502fac45a4b36e97eebcea2b6f735d79fa1610c) | `` python3Packages.rns: 1.3.4 -> 1.3.5 ``                                                                            |
| [`a624a1e5`](https://github.com/NixOS/nixpkgs/commit/a624a1e523e1da72ae36e7db35580846b2f0042a) | `` telemt: 3.4.13 -> 3.4.15 ``                                                                                       |
| [`bfad9c31`](https://github.com/NixOS/nixpkgs/commit/bfad9c31809d5cbdce0a979645b2a8b278744602) | `` libretro.opera: 0-unstable-2026-05-30 -> 0-unstable-2026-06-09 ``                                                 |
| [`eca94635`](https://github.com/NixOS/nixpkgs/commit/eca946355fa56187da2e3929aa41e3d879d81fe4) | `` vuls: 0.39.2 -> 0.39.3 ``                                                                                         |
| [`2684678b`](https://github.com/NixOS/nixpkgs/commit/2684678b1ebb3f668d32f1c543c4bcd2d52c790e) | `` anytype: 0.54.11 -> 0.55.5 ``                                                                                     |
| [`032c72ae`](https://github.com/NixOS/nixpkgs/commit/032c72ae07dddfee120df0b1efb9040cb35932e5) | `` python3Packages.tensorflow-metadata: 1.17.3 -> 1.21.0 ``                                                          |
| [`d96bce98`](https://github.com/NixOS/nixpkgs/commit/d96bce98f2a1dd9002da72d65cb4b97890db4913) | `` systemdgenie: 0.99.0-unstable-2026-05-03 -> 0.99.0-unstable-2026-06-04 ``                                         |
| [`23490a11`](https://github.com/NixOS/nixpkgs/commit/23490a11705fb74a4b0f49a6dba091bc87efaa8e) | `` pfetch: 1.10.0 -> 1.11.0 ``                                                                                       |
| [`591867b0`](https://github.com/NixOS/nixpkgs/commit/591867b0105ad5bd4170e8c6cbb69b68f61a1ebd) | `` alvr: add eyjhb as maintainer ``                                                                                  |
| [`4444b727`](https://github.com/NixOS/nixpkgs/commit/4444b727ab97a5f4cd4c967f278d7caf8da8b2c4) | `` python3Packages.losant-rest: 2.1.4 -> 2.2.0 ``                                                                    |
| [`a15689bc`](https://github.com/NixOS/nixpkgs/commit/a15689bc0d0c2fa9eca8b9b8ab4bdb700cdc4dc6) | `` alvr: use ffmpeg_6 with patches from alvr ``                                                                      |
| [`90f84116`](https://github.com/NixOS/nixpkgs/commit/90f84116c4d7db08368e9251fb5d8a23c607b50c) | `` python3Packages.libmobility: init at 1.1.2 ``                                                                     |
| [`5504124f`](https://github.com/NixOS/nixpkgs/commit/5504124f644fa83585cd48f767bf25529c15f6b3) | `` dcp: 0.24.3 -> 0.25.0 ``                                                                                          |
| [`242b9e45`](https://github.com/NixOS/nixpkgs/commit/242b9e45bfb0891bfc3134488d975fe11c79c277) | `` python3Packages.emmiai-noether: skip newly failing tests ``                                                       |
| [`19c5f7bd`](https://github.com/NixOS/nixpkgs/commit/19c5f7bd7c31966d28dbd39182806d005845e4f4) | `` python3Packages.pybase62: init at 0.5.0 ``                                                                        |
| [`1ec7816d`](https://github.com/NixOS/nixpkgs/commit/1ec7816dd92e26a3e1efce27d52231fbdd1c408d) | `` python3Packages.transformer-engine: 2.15 -> 2.16 ``                                                               |
| [`c010c8e2`](https://github.com/NixOS/nixpkgs/commit/c010c8e2d8eb682b9bbd0fc07addcf253e5817be) | `` muffet: 2.11.4 -> 2.11.5 ``                                                                                       |
| [`2dd0dce2`](https://github.com/NixOS/nixpkgs/commit/2dd0dce26793aa430a183abcc9200f5b49dc7e6c) | `` astro-language-server: 2.16.7 -> 2.16.10 ``                                                                       |
| [`2d4b379f`](https://github.com/NixOS/nixpkgs/commit/2d4b379f8c7d1e6b440057244b7625c4a1d2b7e6) | `` dbeaver-bin: 26.0.5 -> 26.1.0 ``                                                                                  |
| [`123135b1`](https://github.com/NixOS/nixpkgs/commit/123135b1c60dfa5a5e5a437f20e965bbd0c5de48) | `` python3Packages.emmiai-noether: fix by relaxing torch ``                                                          |
| [`6ac58754`](https://github.com/NixOS/nixpkgs/commit/6ac58754dc9d68c6d51084b5b91f80e80cac872d) | `` tombi: modernize ``                                                                                               |
| [`bad61aa4`](https://github.com/NixOS/nixpkgs/commit/bad61aa4237840075f7d54b1811e3e5401afca54) | `` tombi: 0.11.6 -> 1.1.2 ``                                                                                         |
| [`debe0cb4`](https://github.com/NixOS/nixpkgs/commit/debe0cb482d38fbd54c44b32f607057c4c9c1159) | `` tombi: add faukah to maintainers ``                                                                               |
| [`ed6daf6a`](https://github.com/NixOS/nixpkgs/commit/ed6daf6a1ebfbaa8fd1d47615aad206ad86a79b4) | `` vimPlugins.guh-nvim: init at 2026-06-09 ``                                                                        |
| [`91c6e051`](https://github.com/NixOS/nixpkgs/commit/91c6e051363e96351fde09cb8f35590628244087) | `` igir: 5.0.2 -> 5.1.0 ``                                                                                           |
| [`42009e4c`](https://github.com/NixOS/nixpkgs/commit/42009e4c23d5502dd3094d110c04927019ead39c) | `` dix: 2.0.0 -> 2.0.1 ``                                                                                            |
| [`207f1b96`](https://github.com/NixOS/nixpkgs/commit/207f1b9609cd693c31e93fd1c919c54056bf1fb3) | `` keepassxc: set meta.donationPage ``                                                                               |
| [`d1faf06a`](https://github.com/NixOS/nixpkgs/commit/d1faf06ac27095da913eb7271cf84ab23dfa23a7) | `` nixos/rmfakecloud: add martinetd as maintainer ``                                                                 |
| [`31a73caf`](https://github.com/NixOS/nixpkgs/commit/31a73caf2f637a780c7cd2e84fe8bc83b02644d2) | `` misskey: fix pnpm EROFS error ``                                                                                  |
| [`a30bc54b`](https://github.com/NixOS/nixpkgs/commit/a30bc54b6a5b6b7b0ec5b87d2be3a4b013aef369) | `` ty: 0.0.44 -> 0.0.46 ``                                                                                           |
| [`134bfa75`](https://github.com/NixOS/nixpkgs/commit/134bfa753c5e0e7ba953eecf8fd3bc3046a6326a) | `` treefmt.withConfig: add `check` function ``                                                                       |
| [`04c975d0`](https://github.com/NixOS/nixpkgs/commit/04c975d04275c13e62594f3acf1f674b8a35171f) | `` python3Packages.ngff-zarr: 0.34.0 -> 0.35.0 ``                                                                    |
| [`f9ffc813`](https://github.com/NixOS/nixpkgs/commit/f9ffc8139bbdda44fff76e46f255701c69de2e3f) | `` bazaar: 0.8.1 -> 0.8.3 ``                                                                                         |
| [`e36a94df`](https://github.com/NixOS/nixpkgs/commit/e36a94df80164e37e0d247ca5407159bf9c950b3) | `` slade-unstable: 3.2.12-unstable-2026-05-08 -> 3.2.12-unstable-2026-06-08 ``                                       |
| [`4966604c`](https://github.com/NixOS/nixpkgs/commit/4966604cc89c96cab27c8ec7f43336fab912f769) | `` stalwart: remove euxane from maintainers ``                                                                       |
| [`17118eb1`](https://github.com/NixOS/nixpkgs/commit/17118eb1d51324110802ff6dd489e32290f80979) | `` rmfakecloud: remove euxane from maintainers ``                                                                    |
| [`749517a9`](https://github.com/NixOS/nixpkgs/commit/749517a99c92a8441cab32f723ca33c59c0d1017) | `` python3Packages.cyclonedx-python-lib: 11.8.0 -> 11.9.0 ``                                                         |
| [`6b0e0d10`](https://github.com/NixOS/nixpkgs/commit/6b0e0d10f40bda5436c600579273b4b06a1ebac2) | `` python3Packages.yalexs-ble: 3.3.0 -> 3.3.1 ``                                                                     |
| [`c0f295f6`](https://github.com/NixOS/nixpkgs/commit/c0f295f6c5313cfda93197b455dbc67466f45e6b) | `` tempo: 2.10.5 -> 3.0.1 ``                                                                                         |
| [`c59d50c2`](https://github.com/NixOS/nixpkgs/commit/c59d50c27c4c866e1a9677f129e0e132dc281cd9) | `` python3Packages.python-aidot: only auto-update to stable versions ``                                              |
| [`3d6f8942`](https://github.com/NixOS/nixpkgs/commit/3d6f894227c0b30368cb7731fcb47b78b5acafce) | `` android-studio: 2025.3.4.7 -> 2026.1.1.8 ``                                                                       |
| [`2904bb9b`](https://github.com/NixOS/nixpkgs/commit/2904bb9b6b69792689a9f3ac5206d34d14d87bd8) | `` python3Packages.ultraheat-api: 0.6.0 -> 0.6.1 ``                                                                  |
| [`e08080d7`](https://github.com/NixOS/nixpkgs/commit/e08080d79339b3e358b6e9bf73adcd801d505f1e) | `` home-assistant: update component packages ``                                                                      |
| [`874f1522`](https://github.com/NixOS/nixpkgs/commit/874f15227e41fd82a50819b05f53934c92470d85) | `` python3Packages.wassima: use finalAttrs ``                                                                        |
| [`ef1a9dc2`](https://github.com/NixOS/nixpkgs/commit/ef1a9dc2fb31979bff35631bca988d02c50af206) | `` python3Packages.wassima: 2.1.0 -> 2.1.1 ``                                                                        |
| [`c0d0bbd7`](https://github.com/NixOS/nixpkgs/commit/c0d0bbd7b1197a9b82e1d62cf38933de2ad5fa39) | `` tile38: 1.37.0 -> 1.38.0 ``                                                                                       |
| [`5e577d53`](https://github.com/NixOS/nixpkgs/commit/5e577d5351bc741aa3f060c100fcc1dbe8c787af) | `` spotiflac: 7.1.7 -> 7.1.8 ``                                                                                      |
| [`e7632e4b`](https://github.com/NixOS/nixpkgs/commit/e7632e4b9c7b6bcd3e8d35a0643460ef32a26dac) | `` ceph: fuse3 ``                                                                                                    |
| [`ec9a1b8e`](https://github.com/NixOS/nixpkgs/commit/ec9a1b8ee1807cc617fc3ba4f161a88d30a62f09) | `` homebridge-config-ui-x: 5.22.0 -> 5.24.0 ``                                                                       |
| [`fa61e63f`](https://github.com/NixOS/nixpkgs/commit/fa61e63f2451a515939d294a6bd7266f0bfe03fe) | `` hooky: 1.0.3 -> 1.0.4 ``                                                                                          |
| [`46c90246`](https://github.com/NixOS/nixpkgs/commit/46c902468519e8a246e46394eb521d662aaa0011) | `` jsoncons: 1.7.0 -> 1.8.0 ``                                                                                       |
| [`17826ec0`](https://github.com/NixOS/nixpkgs/commit/17826ec06a07ec370765d18eb187e556252f012a) | `` proton-authenticator: 1.1.5 -> 1.1.6 ``                                                                           |
| [`390d8804`](https://github.com/NixOS/nixpkgs/commit/390d88040c578a64ccea7d979c26a2381b8fe705) | `` gitsign: 0.16.0 -> 0.16.1 ``                                                                                      |
| [`1236529e`](https://github.com/NixOS/nixpkgs/commit/1236529ed59871805095f6494162be5bbf7edda2) | `` clickhouse: 26.5.1.882-stable -> 26.5.2.39-stable ``                                                              |
| [`c3602f7b`](https://github.com/NixOS/nixpkgs/commit/c3602f7b269673777a8dd677f75bb1b651f822f1) | `` dtop: 0.7.6 -> 0.7.7 ``                                                                                           |
| [`d2c0334b`](https://github.com/NixOS/nixpkgs/commit/d2c0334b5fee7f36683d4367242a334194a667b3) | `` python3Packages.boto3-stubs: 1.43.24 -> 1.43.25 ``                                                                |
| [`2235fae6`](https://github.com/NixOS/nixpkgs/commit/2235fae655fae9870ddbfa401d2a8af5d914e8e2) | `` python3Packages.mypy-boto3-omics: 1.43.18 -> 1.43.25 ``                                                           |
| [`c5220b3d`](https://github.com/NixOS/nixpkgs/commit/c5220b3d3e42b8cdc9841b55ac7b83d308662c80) | `` python3Packages.mypy-boto3-mgn: 1.43.8 -> 1.43.25 ``                                                              |
| [`88c9b104`](https://github.com/NixOS/nixpkgs/commit/88c9b10410bd313597dfe92d9135e2c25a8a5541) | `` python3Packages.mypy-boto3-mediapackagev2: 1.43.9 -> 1.43.25 ``                                                   |
| [`98e5f81c`](https://github.com/NixOS/nixpkgs/commit/98e5f81c197a71dd88cff3ca858b4aff79e440ed) | `` python3Packages.mypy-boto3-compute-optimizer: 1.43.22 -> 1.43.25 ``                                               |
| [`2b4d1e57`](https://github.com/NixOS/nixpkgs/commit/2b4d1e572a695aad28f427e6eab1da0a626c28f5) | `` fast-float: 8.2.5 -> 8.2.8 ``                                                                                     |
| [`452f761a`](https://github.com/NixOS/nixpkgs/commit/452f761ac7b6f5ce3be2149f131fb09f8df17cac) | `` python3Packages.boto3-stubs: 1.43.23 -> 1.43.24 ``                                                                |
| [`72f44ae3`](https://github.com/NixOS/nixpkgs/commit/72f44ae3cc93778c55eb287278fd84dcf7ac9d59) | `` python3Packages.mypy-boto3-sagemaker: 1.43.23 -> 1.43.24 ``                                                       |
| [`36595bf0`](https://github.com/NixOS/nixpkgs/commit/36595bf08694d4d51aeb3025b410449a0cfa24de) | `` python3Packages.mypy-boto3-quicksight: 1.43.19 -> 1.43.24 ``                                                      |
| [`a9e3ae06`](https://github.com/NixOS/nixpkgs/commit/a9e3ae06a194c86c725299a2a7fa4128ec96258c) | `` python3Packages.mypy-boto3-payment-cryptography: 1.43.1 -> 1.43.24 ``                                             |
| [`ef77bd34`](https://github.com/NixOS/nixpkgs/commit/ef77bd34571d7cf898224e6aad1cdab738b7ab11) | `` python3Packages.mypy-boto3-mediaconvert: 1.43.0 -> 1.43.24 ``                                                     |
| [`33a0add2`](https://github.com/NixOS/nixpkgs/commit/33a0add26ae9584b4bddf58bd4aacb8f7c5d4796) | `` python3Packages.mypy-boto3-emr-serverless: 1.43.0 -> 1.43.24 ``                                                   |
| [`2907df45`](https://github.com/NixOS/nixpkgs/commit/2907df4562c8360b2006180c6e6004d4be3a2b4c) | `` flexget: 3.19.22 -> 3.19.23 ``                                                                                    |
| [`94b4fde4`](https://github.com/NixOS/nixpkgs/commit/94b4fde482a48b8eeae984f8cfc0e9550f4c45da) | `` prettier: use pnpm_10 ``                                                                                          |
| [`7bed4ad8`](https://github.com/NixOS/nixpkgs/commit/7bed4ad8101ef5cd61f53b7551a9fb988a3ec906) | `` zigbee2mqtt: use pnpm_10 ``                                                                                       |
| [`740b34f2`](https://github.com/NixOS/nixpkgs/commit/740b34f2968262db257876c8d60cda97f6b95967) | `` virtualbox: remove not required default.nix from callPackage ``                                                   |
| [`34e34f9b`](https://github.com/NixOS/nixpkgs/commit/34e34f9bf71ce0c68ad3e5d9a72baa1f1fda756e) | `` teleport_18: 18.7.6 -> 18.8.3 ``                                                                                  |
| [`68ae43d2`](https://github.com/NixOS/nixpkgs/commit/68ae43d2ecd65926011686ee492d38906c93d3c1) | `` devin-cli: fix homepage to skip redirect to devin IDE online ``                                                   |
| [`1f9448d9`](https://github.com/NixOS/nixpkgs/commit/1f9448d9d746daf8b338deba5fac784db360971f) | `` ci: update pinned ``                                                                                              |
| [`089cd8fb`](https://github.com/NixOS/nixpkgs/commit/089cd8fbaca2ae8b49c3034ebb99bd9fdad6ff1c) | `` ci/update-pinned.sh: use nixpkgs from current dir, run npins upgrade too ``                                       |
| [`656d35fd`](https://github.com/NixOS/nixpkgs/commit/656d35fdefc4eb9a07286c4a93763e944f0ca72b) | `` octave: 11.2.0 -> 11.3.0 ``                                                                                       |
| [`1e688f13`](https://github.com/NixOS/nixpkgs/commit/1e688f13244ae676ae6ab53583504f8436745dc5) | `` llvmPackages.bintools-unwrapped: inherit `meta.teams` from `llvm` ``                                              |
| [`8a7a621c`](https://github.com/NixOS/nixpkgs/commit/8a7a621c024e9b40078c17f1fc4ecc8f00792442) | `` python3Packages.pure-magic-rs: 0.3.2 -> 0.3.3 ``                                                                  |
| [`03441e00`](https://github.com/NixOS/nixpkgs/commit/03441e004fb4ff6452487db44d67492343d773bf) | `` rura: 1.3.0 -> 1.5.0 ``                                                                                           |
| [`553d0d8c`](https://github.com/NixOS/nixpkgs/commit/553d0d8c9f086cac152510476c1e83282868c286) | `` unblob: 26.3.30 → 26.6.4 ``                                                                                       |
| [`f7bb17f7`](https://github.com/NixOS/nixpkgs/commit/f7bb17f77146bfca7cab89062065a4174e264c26) | `` rabbitmqadmin-ng: 2.29.0 -> 2.32.0 ``                                                                             |
| [`3c67b71d`](https://github.com/NixOS/nixpkgs/commit/3c67b71d70fdc8f9f1028db451238d1505562025) | `` git-pages: 0.9.0 -> 0.9.1 ``                                                                                      |
| [`79d4a5a3`](https://github.com/NixOS/nixpkgs/commit/79d4a5a31cab433a0a87c8b30cf9a53c24d80169) | `` cargo-binstall: 1.19.1 -> 1.20.0 ``                                                                               |
| [`8f26b06d`](https://github.com/NixOS/nixpkgs/commit/8f26b06dc362d8d9658267b596070fb85f524852) | `` pragtical: use mbedtls_4 ``                                                                                       |
| [`9e78dc09`](https://github.com/NixOS/nixpkgs/commit/9e78dc097e1b917c22bb1ee4fe1429c37ede90d4) | `` python3Packages.ha-garmin: 0.1.25 -> 0.1.26 ``                                                                    |
| [`dd5b0898`](https://github.com/NixOS/nixpkgs/commit/dd5b0898caabdfce92599ecff64dd527368fc812) | `` python3Packages.jupyter-docprovider: 2.4.0 -> 2.4.1 ``                                                            |
| [`55fda864`](https://github.com/NixOS/nixpkgs/commit/55fda864571a7ce5e1e2f70fc0133e1583a28e6e) | `` home-assistant-custom-components.opendisplay: init at 2.0.2 ``                                                    |
| [`d8a6f4c8`](https://github.com/NixOS/nixpkgs/commit/d8a6f4c862182443f7e69e6c6be34791a94b4bf6) | `` python3Packages.python-resize-image: init at 1.1.20 ``                                                            |
| [`20f49244`](https://github.com/NixOS/nixpkgs/commit/20f4924437d611980a645a882db16e68e2cfd1a7) | `` python3Packages.indevolt-api: 1.8.3 -> 1.8.5 ``                                                                   |
| [`1120f1fc`](https://github.com/NixOS/nixpkgs/commit/1120f1fcc2a62abf37fca348833d30bf14369789) | `` maintainers: remove hedning ``                                                                                    |
| [`a71186b6`](https://github.com/NixOS/nixpkgs/commit/a71186b66382f1f2ed5b7399b3616767de3a8aeb) | `` gonic: 0.21.0 -> 0.22.0 ``                                                                                        |
| [`bb1e73bf`](https://github.com/NixOS/nixpkgs/commit/bb1e73bf6f4e59616522159d3485d0502b94b884) | `` neovim-require-check-hook: remove `$out` from `rtp` ``                                                            |
| [`ec490ec3`](https://github.com/NixOS/nixpkgs/commit/ec490ec3bafd4914dc141202fce7db2d49ab9c38) | `` treewide: use callPackage instead of python3Packages.callPackage ``                                               |
| [`8bbed877`](https://github.com/NixOS/nixpkgs/commit/8bbed877995f721e7d7f76e959f88166073a7e41) | `` workflows/teams: fix execution day of comment ``                                                                  |
| [`399295a9`](https://github.com/NixOS/nixpkgs/commit/399295a97b7e5b8a7284bd750ffaa2b0adceb1f1) | `` cargo-tauri: use pnpm 10 for test-app ``                                                                          |
| [`fa5aaea6`](https://github.com/NixOS/nixpkgs/commit/fa5aaea66df5c50138bd094b4fc1233be87476e3) | `` maintainers/github-teams.json: Automated sync ``                                                                  |
| [`efb85db5`](https://github.com/NixOS/nixpkgs/commit/efb85db5be6d9dd8bbd13bf68cb57eebec44ce35) | `` lprint: 1.3.1 -> 1.4.0 ``                                                                                         |
| [`8b6e1c34`](https://github.com/NixOS/nixpkgs/commit/8b6e1c347ff559e777397ea68cb964ca77274d3a) | `` python3Packages.google-cloud-securitycenter: migrate to finalAttrs ``                                             |
| [`841eb1c7`](https://github.com/NixOS/nixpkgs/commit/841eb1c7ac92e484bb4af4aeea9f58713cdfefb9) | `` routinator: 0.15.1 -> 0.15.2 ``                                                                                   |
| [`85b39a0b`](https://github.com/NixOS/nixpkgs/commit/85b39a0b0f24c0b7454bd416563f24605acdb2dd) | `` telegraf: 1.38.4 -> 1.39.0 ``                                                                                     |
| [`1d82c985`](https://github.com/NixOS/nixpkgs/commit/1d82c985ab44d48516d27c7f3ab63ad5ac45ef6b) | `` strongswan: 6.0.6 -> 6.0.7 ``                                                                                     |
| [`e89b0361`](https://github.com/NixOS/nixpkgs/commit/e89b0361962fde0aaafbdc05f637d2d465bd42c4) | `` vscodium: set `meta.changelog` ``                                                                                 |
| [`730f6ecd`](https://github.com/NixOS/nixpkgs/commit/730f6ecd330ccba06220da4f9143e782e069703b) | `` vscode: set `meta.changelog` ``                                                                                   |
| [`f2cf50e2`](https://github.com/NixOS/nixpkgs/commit/f2cf50e27586b845687a4c2a465fb141e73dcf19) | `` ollama: 0.30.5 -> 0.30.6 ``                                                                                       |
| [`d2903d5b`](https://github.com/NixOS/nixpkgs/commit/d2903d5b59f8b3d55f2a281a405b4e435b225a01) | `` terraform-ls: 0.38.6 -> 0.38.7 ``                                                                                 |
| [`260d1c6c`](https://github.com/NixOS/nixpkgs/commit/260d1c6c8158dbaaca14218bfe4e6315a55bb84c) | `` nixos/llama-cpp: switch to RFC42-style settings ``                                                                |
| [`5671ac27`](https://github.com/NixOS/nixpkgs/commit/5671ac2736b8af922df4f245c906fed58b3f1f0f) | `` pgrok: add tbutter to maintainers ``                                                                              |
| [`620e770a`](https://github.com/NixOS/nixpkgs/commit/620e770acf0f35915d3ee219fb6f31ff13d254a5) | `` sketchybar-app-font: migrate to pnpm_11 ``                                                                        |
| [`c527ba0b`](https://github.com/NixOS/nixpkgs/commit/c527ba0b94c3a9b7276e7f2abaff459d40c6078c) | `` borgmatic: switch to finalAttrs, fix eval error with optional-dependencies, use strictDeps and structuredAttrs `` |
| [`03b97822`](https://github.com/NixOS/nixpkgs/commit/03b97822bf9476ad984b6f6db33d3ffd17a1ee52) | `` python3Packages.stravalib: 2.4 -> 2.5.0 ``                                                                        |
| [`3bf742cc`](https://github.com/NixOS/nixpkgs/commit/3bf742ccb0336447c15e1bb6fddf882ff89afff9) | `` digikam: 9.0.0 -> 9.1.0 ``                                                                                        |
| [`ab88b2e1`](https://github.com/NixOS/nixpkgs/commit/ab88b2e13518615f14d797383dd2a7b80b3d12b0) | `` gs1200-exporter: add release notes entry ``                                                                       |
| [`cf53c7c9`](https://github.com/NixOS/nixpkgs/commit/cf53c7c9175dbae1b856c199f9c08b1a5cdf3be4) | `` nixos/gs1200-exporter: init module ``                                                                             |
| [`3803757a`](https://github.com/NixOS/nixpkgs/commit/3803757a2c0451c17ffdc92291a9835f20977c5b) | `` gs1200-exporter: init at 2.11.12 ``                                                                               |
| [`955eadbe`](https://github.com/NixOS/nixpkgs/commit/955eadbe8638b265fffa0ee49f9124201568d925) | `` python3Packages.tuya-device-sharing-sdk: 0.2.9 -> 0.2.10 ``                                                       |
| [`6f45ba6c`](https://github.com/NixOS/nixpkgs/commit/6f45ba6c6d7603408fbbdd783cd12a3524553a3a) | `` maintainers: add DerGrumpf ``                                                                                     |
| [`4276b628`](https://github.com/NixOS/nixpkgs/commit/4276b628cccfe1a18acf1118ddc8222c7634a71d) | `` openmm: 8.5.1 -> 8.5.2 ``                                                                                         |
| [`682823e9`](https://github.com/NixOS/nixpkgs/commit/682823e9c3467a69c109410436480eb9680b25fc) | `` deltachat-tauri: inherit from deltachat-desktop ``                                                                |
| [`938ee4c2`](https://github.com/NixOS/nixpkgs/commit/938ee4c22d5569f8f710a07b090a4eeafc99e68a) | `` offlineimap: 8.0.2 -> 8.0.3 ``                                                                                    |
| [`88586c38`](https://github.com/NixOS/nixpkgs/commit/88586c388144e2b628a253ce4658bd3d0d950016) | `` ashell: 0.8.0 -> 0.9.0, added nix-update-script, update license ``                                                |
| [`238f865c`](https://github.com/NixOS/nixpkgs/commit/238f865c578dcba8dbd0ad4f40aee51c37368aaa) | `` luaPackages.coop-nvim: init at 1.2.0-0 ``                                                                         |
| [`fb86fecd`](https://github.com/NixOS/nixpkgs/commit/fb86fecd8cb861977496c8db6db8be50ffed7951) | `` chiri: 0.9.0 -> 0.9.1 ``                                                                                          |
| [`92b73415`](https://github.com/NixOS/nixpkgs/commit/92b73415503b75385e4da2b1c999b7f804d93e04) | `` anytype-heart: 0.49.0-rc08 -> 0.50.8 ``                                                                           |
| [`8240fc2f`](https://github.com/NixOS/nixpkgs/commit/8240fc2f01a27ec6454f416745dd216a5c366858) | `` woeusb-ng: add ntfs3g dependency ``                                                                               |
| [`4bd030a4`](https://github.com/NixOS/nixpkgs/commit/4bd030a4658092f4d936a382f2cadcb35dbee8ca) | `` code-cursor: 3.6.21 -> 3.7.19 ``                                                                                  |
| [`90cfe6da`](https://github.com/NixOS/nixpkgs/commit/90cfe6da9e0ede5bc90811d2a2a967691b975463) | `` python3Packages.trsfile: modernize ``                                                                             |
| [`9361dadb`](https://github.com/NixOS/nixpkgs/commit/9361dadbbfe817bbfbb4cf5cfe6f1011c6d553c7) | `` python3Packages.trsfile: move env variable into env for structuredAttrs ``                                        |
| [`8659931a`](https://github.com/NixOS/nixpkgs/commit/8659931ac0743de6eeac91df0ef1a27ab0f36298) | `` redshift: adopt by acidbong ``                                                                                    |
| [`153c3c36`](https://github.com/NixOS/nixpkgs/commit/153c3c36af1d2b038ad4b05335bcaefb44df1e9f) | `` ci/OWNERS: add gnome team as owner of gnome related packages ``                                                   |
| [`dc0c61e4`](https://github.com/NixOS/nixpkgs/commit/dc0c61e4450744093395789b6ea3192e1e81f341) | `` scanservjs: link nixosTests ``                                                                                    |
| [`32157e1c`](https://github.com/NixOS/nixpkgs/commit/32157e1c527cd71127d5344aaa411eea0f0233b8) | `` nixosTests.scanservjs: init ``                                                                                    |
| [`008e87e5`](https://github.com/NixOS/nixpkgs/commit/008e87e5c2921c678daf0a11b2a765ea52a1f558) | `` scanservjs: package the backend with the frontend ``                                                              |
| [`c2c5e383`](https://github.com/NixOS/nixpkgs/commit/c2c5e3839d57c6b364634f4e7f3152cb56a3b561) | `` gpxsee: 16.7 -> 16.8 ``                                                                                           |
| [`16c721fe`](https://github.com/NixOS/nixpkgs/commit/16c721fec69d065053a4a6f8ef2465ff0e18209d) | `` python3Packages.securityreporter: 1.4.0 -> 1.5.0 ``                                                               |
| [`54d9241d`](https://github.com/NixOS/nixpkgs/commit/54d9241d9a142e11dca58ecb44d1bdbaf2929e9e) | `` taze: bump to pnpm 11 ``                                                                                          |
| [`8960efe8`](https://github.com/NixOS/nixpkgs/commit/8960efe83554b8c9daa05c10ddf59612f57311a3) | `` mpdris2: adopt by acidbong ``                                                                                     |
| [`217c4577`](https://github.com/NixOS/nixpkgs/commit/217c4577228a41fe9b958c337961213e5c5a2ed8) | `` moltengamepad: unstable-2016-05-04 -> 1.2.1 ``                                                                    |
| [`3982b13c`](https://github.com/NixOS/nixpkgs/commit/3982b13c0d01eb589ee2661fffed60753a697f32) | `` immudb: add hythera as maintainer ``                                                                              |
| [`f6833f3b`](https://github.com/NixOS/nixpkgs/commit/f6833f3bb389d59f802a6d6099e1e51ec405a8c9) | `` protoc-gen-elixir: 0.16.0 -> 0.17.0 ``                                                                            |
| [`b6973f1c`](https://github.com/NixOS/nixpkgs/commit/b6973f1c8acd175a9616d833456140427ae978fa) | `` immudb: modernize ``                                                                                              |
| [`2eaf7e14`](https://github.com/NixOS/nixpkgs/commit/2eaf7e14b5cf542483e64cc038662b07c5ba4cba) | `` mldonkey: migrate to by-name ``                                                                                   |
| [`e7f46298`](https://github.com/NixOS/nixpkgs/commit/e7f46298602fa5be6b15a63a93827770e53514bc) | `` mldonkey: switch to finalAttrs, use structuredAttrs, move attribute out of top-level ``                           |
| [`98605668`](https://github.com/NixOS/nixpkgs/commit/98605668fb15745476ef53e7711d6ffa8b520c2c) | `` immudb: 1.10.0 -> 1.11.0 ``                                                                                       |
| [`d74ffb2d`](https://github.com/NixOS/nixpkgs/commit/d74ffb2d2d4a68c64641bcf1c0716925c241d507) | `` gleam: fix linux build by skipping network test ``                                                                |
| [`abd36e37`](https://github.com/NixOS/nixpkgs/commit/abd36e37c11af7777a0c799fb9c6e37867315ef3) | `` sqlpage: add hythera as maintainer ``                                                                             |
| [`b221369b`](https://github.com/NixOS/nixpkgs/commit/b221369b3833944c1fbf241e77c58f645372d345) | `` rgx: 0.12.6 -> 0.14.1 ``                                                                                          |
| [`5b528062`](https://github.com/NixOS/nixpkgs/commit/5b52806222e139d70d7a55ae2dfd8fcc25256524) | `` yacreader: 9.16.3 -> 10.0.0 ``                                                                                    |
| [`f9dc47ee`](https://github.com/NixOS/nixpkgs/commit/f9dc47ee618759ec823ba199d15fb4fac3960f5e) | `` rtorrent: 0.16.11 -> 0.16.13 ``                                                                                   |
| [`cef1af8b`](https://github.com/NixOS/nixpkgs/commit/cef1af8bb919c912b98f9b4b3cab5dc6816bb191) | `` sqlpage: modernize ``                                                                                             |
| [`c9a77d67`](https://github.com/NixOS/nixpkgs/commit/c9a77d67c03bdf32629d54c9658f5ee8f04a018e) | `` sqlpage: 0.41.0 -> 0.44.0 ``                                                                                      |
| [`c4770048`](https://github.com/NixOS/nixpkgs/commit/c477004805e793b4a3f00d3c67b36828c2abf176) | `` nixos/lauti: remove nonsensical comment ``                                                                        |
| [`d81ee288`](https://github.com/NixOS/nixpkgs/commit/d81ee288f6d31163fd44ec51287ff4c529b2ff45) | `` deltachat-desktop: use __structuredAttrs and strictDeps ``                                                        |
| [`e7e6095b`](https://github.com/NixOS/nixpkgs/commit/e7e6095be18ccaf814314d48ddc37a94da97316a) | `` deltachat-tauri: use pnpm_10 ``                                                                                   |
| [`34737cba`](https://github.com/NixOS/nixpkgs/commit/34737cba685fc199953a5f9101d0ec5505b14054) | `` deltachat-desktop: use pnpm_10 ``                                                                                 |
| [`2d2cce7f`](https://github.com/NixOS/nixpkgs/commit/2d2cce7f4cb3314bc1f532d3de3d1c9eeab7c247) | `` fastfetch: add support for codec module ``                                                                        |
| [`b0099763`](https://github.com/NixOS/nixpkgs/commit/b0099763f8624435e683ef2633ddd25cf54e8166) | `` home-assistant-custom-components.octopus_energy: 18.3.0 -> 18.3.1 ``                                              |
| [`be0515c3`](https://github.com/NixOS/nixpkgs/commit/be0515c3a384e56b20acc722bdc7759f8efa99ff) | `` prqlc: add hythera as maintainer ``                                                                               |
| [`6d5e7c07`](https://github.com/NixOS/nixpkgs/commit/6d5e7c07ed26dc5f5fbea0965b2cd4f689fcbee1) | `` vscode-extensions.tombi-toml.tombi: 1.1.1 -> 1.1.2 ``                                                             |
| [`6dc69608`](https://github.com/NixOS/nixpkgs/commit/6dc6960872d5d46b7e04a1bc114f51f9d38acdcf) | `` prqlc: modernize ``                                                                                               |
| [`0b4b4bcd`](https://github.com/NixOS/nixpkgs/commit/0b4b4bcd584170eb84b0a127a4b7a617aeb2b525) | `` prqlc: 0.13.10 -> 0.13.12 ``                                                                                      |
| [`bb6913c3`](https://github.com/NixOS/nixpkgs/commit/bb6913c30411a078c177a012bd4a31388d59cca4) | `` emacs: enable __structuredAttrs ``                                                                                |
| [`a9076c26`](https://github.com/NixOS/nixpkgs/commit/a9076c26ad03ee4387020f21811370dc2c91a4ab) | `` python3Packages.mmengine: skip failing test ``                                                                    |
| [`2a004027`](https://github.com/NixOS/nixpkgs/commit/2a004027d77f0281720b193e80a7d95bde2f70ef) | `` fastfetch: 2.63.1 -> 2.64.2 ``                                                                                    |
| [`dcb916de`](https://github.com/NixOS/nixpkgs/commit/dcb916de009671e1080f1ad0b6efb23ee01e4f8b) | `` shadowsocks-libev: 3.3.5 -> 3.3.6 ``                                                                              |
| [`ae20b786`](https://github.com/NixOS/nixpkgs/commit/ae20b786b694c6afb2df26c8252b49db556d7b43) | `` python3Packages.pydo: 0.34.0 -> 0.35.0 ``                                                                         |
| [`7a0b7321`](https://github.com/NixOS/nixpkgs/commit/7a0b73217279f9fbe5546a3723a98ef5ca02dd01) | `` python3Packages.aioaudiobookshelf: 0.1.20 -> 0.1.21 ``                                                            |
| [`8f8a576b`](https://github.com/NixOS/nixpkgs/commit/8f8a576bd7523f087c1989e57070491ce229195b) | `` werf: 2.69.0 -> 2.69.1 ``                                                                                         |
| [`638daaad`](https://github.com/NixOS/nixpkgs/commit/638daaadb3b91988157b193ee30ec5d0e1251b35) | `` necesse-server: 1.2.0-22728942 -> 1.2.0-23522718 ``                                                               |
| [`7c491cd1`](https://github.com/NixOS/nixpkgs/commit/7c491cd136dfcf1658ba9cd228ceec12b702c4a6) | `` abcmidi: 2026.04.26 -> 2026.06.06 ``                                                                              |
| [`50f2e0e1`](https://github.com/NixOS/nixpkgs/commit/50f2e0e108c75e47c622ee90cdf52b6d98152f81) | `` jetbrains.idea: 2026.1.1 -> 2026.1.3 ``                                                                           |
| [`9f218ef7`](https://github.com/NixOS/nixpkgs/commit/9f218ef73eae09f63359a98a8551bcd87b73bf12) | `` jetbrains.phpstorm: 2026.1.2 -> 2026.1.3 ``                                                                       |
| [`fd3875b5`](https://github.com/NixOS/nixpkgs/commit/fd3875b5e44f022185bc7f7edc96e7813dc003d4) | `` geekbench6: add riscv64-linux ``                                                                                  |
| [`9c4068ff`](https://github.com/NixOS/nixpkgs/commit/9c4068ff6ee3bf1a7650ed9ec6b893fa2c8e7075) | `` jetbrains.ruby-mine: 2026.1.2 -> 2026.1.3 ``                                                                      |
| [`3a78aa30`](https://github.com/NixOS/nixpkgs/commit/3a78aa305c35c3f5a28e9c80380e4f6613160939) | `` jetbrains.gateway: 2026.1.2 -> 2026.1.3 ``                                                                        |
| [`3cbd1a97`](https://github.com/NixOS/nixpkgs/commit/3cbd1a97c2d6f57a2c6b73bd47502b7d45a9b85d) | `` freetube: 0.24.0 -> 0.24.1 ``                                                                                     |
| [`28465b62`](https://github.com/NixOS/nixpkgs/commit/28465b628faafabf9ed5c7005c85eeb8b918636e) | `` gridcoin-research: 5.5.0.0 -> 5.5.1.0 ``                                                                          |
| [`ca6262ad`](https://github.com/NixOS/nixpkgs/commit/ca6262ad599f996ab2ff376162f89ecb3629ae6e) | `` geekbench_6: 6.4.0->6.7.1 ``                                                                                      |
| [`27a8ad8d`](https://github.com/NixOS/nixpkgs/commit/27a8ad8da0d098f4325ca9a45926c51670ff37ac) | `` geekbench: move to by-name ``                                                                                     |

*... and 2910 more commits (truncated)*